### PR TITLE
Add support for scene background audio playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # RolePlayScene (client-side branching story builder)
 
-A 100% front-end tool (HTML/CSS/JS) for building and playing simple branching role-play stories. Creators can define up to **20 scenes** (exactly **1 Start**, up to **3 Endings**, the rest Intermediate). Each scene has **1 image**, **up to 2 dialogue lines** (each may include an **MP3**), and **up to 3 response choices** that branch to other scenes. No server—everything runs in the browser, and projects can be **exported/imported** as JSON (optionally zipped with assets).
+A 100% front-end tool (HTML/CSS/JS) for building and playing simple branching role-play stories. Creators can define up to **20 scenes** (exactly **1 Start**, up to **3 Endings**, the rest Intermediate). Each scene supports **1 image**, **up to 2 dialogue lines** (each may include optional audio), and **up to 3 response choices** that branch to other scenes. No server—everything runs in the browser. Projects export to a **self-contained `.zip` archive** (with media + manifest) and can still import legacy `.json` files; state is also **autosaved** to IndexedDB while you work.
 
 ## ✨ Features
 - **Edit Mode**: graph canvas + inspector to add scenes, set Start/End, upload image/MP3s, author dialogue & choices, connect branches.
 - **Play Mode**: left **Stage** shows scene image; right **Dialogue** auto-steps lines (with audio); then shows choices to branch.
 - **Validation**: exactly 1 Start; ≤3 Endings; ≤20 scenes; no broken links; warns on unreachable scenes.
-- **Storage**: IndexedDB for in-browser work; export/import to JSON (or ZIP).
+- **Storage**: Autosave to IndexedDB with graceful fallbacks; manual export creates a `.zip` archive (manifest + binary media) while import accepts both `.zip` and legacy `.json` snapshots.
 - **Privacy**: all processing happens locally in the browser.
 - **Mobile friendly**: touch targets, iOS autoplay guard (“Start Playback”).
 - **A11y**: keyboard navigation, visible focus, text captions with audio.
 
 ## 🧱 Tech & architecture
 - **No build required**: vanilla ES modules + CSS.
-- **Optional dev tooling**: Vite for local preview and PWA later.
-- **Data**: project state kept in memory and mirrored to IndexedDB; export to JSON (optionally base64-embedding or zipped).
+- **Local preview**: any static file server (e.g. `npx http-server public -p 4173`).
+- **Data**: project state kept in memory and mirrored to IndexedDB; export produces a zipped archive (`project.json` manifest + binary media) and import accepts both the archive and JSON snapshots.
 - **Audio**: HTMLAudio (simple) with user-gesture gate; can upgrade to Web Audio API for fine control later.
 - **Graph**: lightweight node/edge model; pan/zoom canvas.
 
@@ -29,7 +29,7 @@ A 100% front-end tool (HTML/CSS/JS) for building and playing simple branching ro
     main.js            # entry, mode switching, global events
     state.js           # app state store, pub/sub
     model.js           # schema, validators, migrations
-    storage.js         # IndexedDB adapter + import/export (JSON/ZIP)
+    storage.js         # IndexedDB adapter + import/export (JSON)
     editor/
       editor.js        # edit mode controller
       graph.js         # graph canvas (render, pan/zoom, hit test)
@@ -46,30 +46,81 @@ A 100% front-end tool (HTML/CSS/JS) for building and playing simple branching ro
   e2e/                 # playthroughs to endings
 ```
 
-## 🗃️ Data model (JSON overview)
-```json
+## 🗃️ Data model snapshot
+
+### In-memory project shape
+```js
 {
-  "meta": { "title": "My Role Play", "version": 1 },
-  "scenes": [{
-    "id": "scene-001",
-    "type": "start|intermediate|end",
-    "image": { "name": "start.png", "blobId": "img-abc", "width": 0, "height": 0 },
-    "dialogue": [
-      { "text": "Hello!", "audio": { "name": "hello.mp3", "blobId": "aud-001", "duration": 0 } },
-      { "text": "Are you ready?", "audio": { "name": "ready.mp3", "blobId": "aud-002", "duration": 0 } }
-    ],
-    "choices": [
-      { "id": "choice-1", "label": "Yes", "nextSceneId": "scene-002" },
-      { "id": "choice-2", "label": "No", "nextSceneId": "scene-003" }
-    ],
-    "notes": ""
+  meta: { title: 'My Role Play', version: 1 },
+  scenes: [{
+    id: 'scene-001',
+    type: 'start' | 'intermediate' | 'end',
+    image: {
+      name: 'start.png',
+      objectUrl: 'blob:https://…',
+      blob: File | Blob | null,
+    } | null,
+    backgroundAudio: {
+      name: 'loop.mp3',
+      objectUrl: 'blob:https://…',
+      blob: File | Blob | null,
+    } | null,
+    dialogue: [{
+      text: 'Hello!',
+      audio: {
+        name: 'hello.mp3',
+        objectUrl: 'blob:https://…',
+        blob: File | Blob | null,
+      } | null,
+    }],
+    choices: [{ id: 'choice-1', label: 'Yes', nextSceneId: 'scene-002' }],
+    autoNextSceneId: null,
+    notes: '',
   }],
-  "assets": [
-    { "id": "img-abc", "type": "image/png" },
-    { "id": "aud-001", "type": "audio/mpeg" }
-  ]
+  assets: [],
 }
 ```
+
+### Serialized for persistence / export
+- **Autosave / legacy export**: persists the pre-existing JSON snapshot (media references contain names only).
+- **`.zip` export**: creates an archive with `project.json` + binary assets.
+
+`project.json` acts as a manifest:
+
+```json
+{
+  "manifestVersion": 1,
+  "project": {
+    "meta": { "title": "My Role Play", "version": 1 },
+    "scenes": [{
+      "id": "scene-001",
+      "type": "start",
+      "image": {
+        "name": "start.png",
+        "type": "image/png",
+        "size": 34567,
+        "path": "media/scene-1/image.png"
+      },
+      "backgroundAudio": null,
+      "dialogue": [{
+        "text": "Hello!",
+        "audio": {
+          "name": "hello.mp3",
+          "type": "audio/mpeg",
+          "size": 78901,
+          "path": "media/scene-1/dialogue-1.mp3"
+        }
+      }],
+      "choices": [{ "id": "choice-1", "label": "Yes", "nextSceneId": "scene-002" }],
+      "autoNextSceneId": null,
+      "notes": ""
+    }],
+    "assets": []
+  }
+}
+```
+
+For each manifest entry with a `path`, the archive includes a binary file at that path. Asset sizes therefore equal the sum of all blobs (plus a few KB for JSON/ZIP overhead). When exporting or importing large media bundles the UI displays “Preparing export…” / “Importing project…” statuses so users know the operation is still running.
 
 ## ✅ Validation rules
 - Exactly **1** scene marked `type = "start"`.
@@ -93,11 +144,13 @@ Keyboard navigation, focus styles, ARIA roles, visible captions.
 Latest Chrome/Edge/Firefox/Safari. iOS Safari requires an initial tap for audio.
 
 ## 🚀 Getting started (dev)
-- Option A: open `public/index.html` directly.
-- Option B (recommended): use a local static server or Vite for fast reload.
+1. Install a recent Node.js runtime (18+) for running tests.
+2. Start a static server from the repo root, e.g. `npx http-server public -p 4173` or `python -m http.server 4173 --directory public`.
+3. Visit `http://localhost:4173` and the app will boot into Edit mode after setting up persistence.
 
 ## 🧪 Testing
-Unit (validators, transitions), Integration (import/export, audio gate), E2E (playthroughs).
+- Run all unit tests: `for f in tests/*.test.mjs; do echo "Running $f"; node "$f"; done`
+- Key coverage includes model helpers, validators, and IndexedDB serialization/hydration round-trips.
 
 ## 🔒 Security & privacy
 No network calls; media handled locally; warn on export.

--- a/public/index.html
+++ b/public/index.html
@@ -12,16 +12,19 @@
     <nav class="toolbar">
       <button id="mode-edit" class="active">Edit</button>
       <button id="mode-play">Play</button>
-      <button id="import-btn" title="Import project JSON">Import</button>
-      <button id="export-btn" title="Export project JSON">Export</button>
+      <button id="import-btn" title="Import project (.json or .zip)">Import</button>
+      <button id="export-btn" title="Export project archive (.zip)">Export</button>
       <label class="file-input">
-        <input type="file" id="file-input" accept=".json" hidden />
+        <input type="file" id="file-input" accept=".json,.zip" hidden />
       </label>
     </nav>
   </header>
 
   <div id="app-messages" class="app-messages" aria-live="polite" role="status" hidden>
-    <span class="app-messages__text"></span>
+    <div class="app-messages__content">
+      <span class="app-messages__text"></span>
+      <div class="app-messages__details validation-results" hidden></div>
+    </div>
     <button type="button" class="app-messages__dismiss" aria-label="Dismiss message">&times;</button>
   </div>
 

--- a/public/scripts/editor/editor.js
+++ b/public/scripts/editor/editor.js
@@ -81,6 +81,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
     const validationResults = validateProject(project);
 
     renderInspector(inspectorHost, project, scene, {
+      onUpdateProjectTitle: updateProjectTitle,
       onAddScene: addScene,
       onDeleteScene: deleteScene,
       onSetSceneType: setSceneType,
@@ -115,6 +116,17 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
         }
       }
     }
+  }
+
+  function updateProjectTitle(title) {
+    const value = typeof title === 'string' ? title : '';
+    mutateProject(prev => ({
+      ...prev,
+      meta: {
+        ...(prev.meta || {}),
+        title: value,
+      },
+    }));
   }
 
   function addScene() {
@@ -207,6 +219,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
           draft.image = {
             name: file.name,
             objectUrl: URL.createObjectURL(file),
+            blob: file,
           };
         }
         return draft;
@@ -230,6 +243,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
           draft.backgroundAudio = {
             name: file.name,
             objectUrl: URL.createObjectURL(file),
+            blob: file,
           };
         }
         return draft;
@@ -298,6 +312,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
           draft.dialogue[index].audio = {
             name: file.name,
             objectUrl: URL.createObjectURL(file),
+            blob: file,
           };
         }
         return draft;

--- a/public/scripts/editor/editor.js
+++ b/public/scripts/editor/editor.js
@@ -41,6 +41,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
   function cloneScene(scene) {
     return {
       ...scene,
+      backgroundAudio: scene.backgroundAudio ? { ...scene.backgroundAudio } : null,
       dialogue: scene.dialogue.map(line => ({
         text: line.text,
         audio: line.audio ? { ...line.audio } : null,
@@ -84,6 +85,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
       onDeleteScene: deleteScene,
       onSetSceneType: setSceneType,
       onSetSceneImage: setSceneImage,
+      onSetSceneBackgroundAudio: setSceneBackgroundAudio,
       onAddDialogue: addDialogue,
       onRemoveDialogue: removeDialogue,
       onUpdateDialogueText: updateDialogueText,
@@ -141,6 +143,9 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
     }
     if (scene.image?.objectUrl) {
       URL.revokeObjectURL(scene.image.objectUrl);
+    }
+    if (scene.backgroundAudio?.objectUrl) {
+      URL.revokeObjectURL(scene.backgroundAudio.objectUrl);
     }
     scene.dialogue.forEach(line => {
       if (line.audio?.objectUrl) {
@@ -209,6 +214,31 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
       return { ...prev, scenes };
     });
     showMessage(file ? `Updated image for ${sceneId}.` : `Removed image for ${sceneId}.`);
+  }
+
+  function setSceneBackgroundAudio(sceneId, file) {
+    mutateProject(prev => {
+      const scenes = prev.scenes.map(scene => {
+        if (scene.id !== sceneId) return scene;
+        const draft = cloneScene(scene);
+        if (draft.backgroundAudio?.objectUrl) {
+          URL.revokeObjectURL(draft.backgroundAudio.objectUrl);
+        }
+        if (!file) {
+          draft.backgroundAudio = null;
+        } else {
+          draft.backgroundAudio = {
+            name: file.name,
+            objectUrl: URL.createObjectURL(file),
+          };
+        }
+        return draft;
+      });
+      return { ...prev, scenes };
+    });
+    showMessage(file
+      ? `Updated background audio for ${sceneId}.`
+      : `Removed background audio for ${sceneId}.`);
   }
 
   function addDialogue(sceneId) {

--- a/public/scripts/editor/inspector.js
+++ b/public/scripts/editor/inspector.js
@@ -91,6 +91,43 @@ export function renderInspector(hostEl, project, scene, actions) {
 
   hostEl.appendChild(imageField);
 
+  const backgroundField = document.createElement('div');
+  backgroundField.className = 'field';
+  const backgroundLabel = document.createElement('span');
+  backgroundLabel.textContent = 'Background music';
+  backgroundField.appendChild(backgroundLabel);
+
+  if (scene.backgroundAudio) {
+    const info = document.createElement('div');
+    info.className = 'audio-info';
+    info.textContent = `Attached: ${scene.backgroundAudio.name || 'Untitled track'}`;
+    backgroundField.appendChild(info);
+  } else {
+    const emptyInfo = document.createElement('p');
+    emptyInfo.className = 'hint';
+    emptyInfo.textContent = 'No background track selected.';
+    backgroundField.appendChild(emptyInfo);
+  }
+
+  const backgroundInput = document.createElement('input');
+  backgroundInput.type = 'file';
+  backgroundInput.accept = 'audio/*';
+  backgroundInput.addEventListener('change', (event) => {
+    const file = event.target.files?.[0];
+    actions.onSetSceneBackgroundAudio?.(scene.id, file || null);
+  });
+  backgroundField.appendChild(backgroundInput);
+
+  if (scene.backgroundAudio) {
+    const removeBgButton = document.createElement('button');
+    removeBgButton.type = 'button';
+    removeBgButton.textContent = 'Remove background music';
+    removeBgButton.addEventListener('click', () => actions.onSetSceneBackgroundAudio?.(scene.id, null));
+    backgroundField.appendChild(removeBgButton);
+  }
+
+  hostEl.appendChild(backgroundField);
+
   // Dialogue
   const dialogueSection = document.createElement('section');
   dialogueSection.className = 'dialogue-editor';

--- a/public/scripts/editor/inspector.js
+++ b/public/scripts/editor/inspector.js
@@ -4,15 +4,27 @@ export function renderInspector(hostEl, project, scene, actions) {
   hostEl.innerHTML = '';
   hostEl.classList.add('inspector');
 
+  const projectTitleField = document.createElement('label');
+  projectTitleField.className = 'field';
+  projectTitleField.innerHTML = '<span>Project title</span>';
+  const projectTitleInput = document.createElement('input');
+  projectTitleInput.type = 'text';
+  projectTitleInput.value = project.meta?.title ?? '';
+  projectTitleInput.placeholder = 'Untitled Role Play';
+  projectTitleInput.maxLength = 120;
+  projectTitleInput.dataset.focusKey = 'project-title';
+  projectTitleInput.addEventListener('input', () => {
+    actions.onUpdateProjectTitle?.(projectTitleInput.value);
+  });
+  projectTitleField.appendChild(projectTitleInput);
+  hostEl.appendChild(projectTitleField);
+
   if (!scene) {
     const empty = document.createElement('p');
     empty.textContent = 'No scenes yet. Use “Add Scene” to begin.';
     hostEl.appendChild(empty);
     return;
   }
-
-  const validationBox = document.createElement('div');
-  validationBox.className = 'validation-results';
 
   const header = document.createElement('div');
   header.className = 'inspector-header';
@@ -306,19 +318,20 @@ export function renderInspector(hostEl, project, scene, actions) {
   }
   hostEl.appendChild(choiceSection);
 
-  renderValidation(actions.validationResults, validationBox);
-  hostEl.appendChild(validationBox);
 }
 
-function renderValidation(result, host) {
+export function renderValidation(result, host, options = {}) {
+  const { showEmptyState = true } = options;
   host.innerHTML = '';
   if (!result) return;
   const { errors = [], warnings = [] } = result;
   if (!errors.length && !warnings.length) {
-    const ok = document.createElement('p');
-    ok.className = 'validation-ok';
-    ok.textContent = 'No validation issues found.';
-    host.appendChild(ok);
+    if (showEmptyState) {
+      const ok = document.createElement('p');
+      ok.className = 'validation-ok';
+      ok.textContent = 'No validation issues found.';
+      host.appendChild(ok);
+    }
     return;
   }
 

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,13 +1,15 @@
 import { Store } from './state.js';
 import { renderEditor } from './editor/editor.js';
 import { renderPlayer } from './player/player.js';
-import { importProject, exportProject } from './storage.js';
+import { importProject, exportProject, setupPersistence } from './storage.js';
 import { validateProject } from './editor/validators.js';
+import { renderValidation } from './editor/inspector.js';
 
 const elLeft = document.getElementById('left-pane');
 const elRight = document.getElementById('right-pane');
 const messageHost = document.getElementById('app-messages');
 const messageText = messageHost?.querySelector('.app-messages__text');
+const messageDetails = messageHost?.querySelector('.app-messages__details');
 const dismissButton = messageHost?.querySelector('.app-messages__dismiss');
 
 const btnEdit = document.getElementById('mode-edit');
@@ -20,6 +22,7 @@ const store = new Store();
 
 let mode = 'edit'; // 'edit' | 'play'
 let teardown = null;
+let persistenceCleanup = () => {};
 
 function setMode(next) {
   if (teardown) {
@@ -37,19 +40,45 @@ function setMode(next) {
 }
 
 function showMessage(msg) {
-  if (!messageHost || !messageText) return;
+  if (!messageHost || !messageText || !messageDetails) return;
   if (!msg) {
     clearMessage();
     return;
   }
-  messageText.textContent = msg;
-  messageHost.hidden = false;
+
+  const payload = typeof msg === 'string' ? { text: msg } : msg;
+  const text = payload.text ?? '';
+  const errors = Array.isArray(payload.errors) ? payload.errors : [];
+  const warnings = Array.isArray(payload.warnings) ? payload.warnings : [];
+  const hasErrors = errors.length > 0;
+  const hasWarnings = warnings.length > 0;
+
+  messageText.textContent = text;
+
+  if (hasErrors || hasWarnings) {
+    renderValidation({ errors, warnings }, messageDetails, { showEmptyState: false });
+    messageDetails.hidden = false;
+  } else {
+    messageDetails.innerHTML = '';
+    messageDetails.hidden = true;
+  }
+
+  if (text || hasErrors || hasWarnings) {
+    messageHost.hidden = false;
+    messageHost.removeAttribute('hidden');
+  } else {
+    messageHost.hidden = true;
+    messageHost.setAttribute('hidden', '');
+  }
 }
 
 function clearMessage() {
-  if (!messageHost || !messageText) return;
+  if (!messageHost || !messageText || !messageDetails) return;
   messageText.textContent = '';
+  messageDetails.innerHTML = '';
+  messageDetails.hidden = true;
   messageHost.hidden = true;
+  messageHost.setAttribute('hidden', '');
 }
 
 if (dismissButton) {
@@ -62,7 +91,11 @@ btnEdit.addEventListener('click', () => setMode('edit'));
 btnPlay.addEventListener('click', () => {
   const result = validateProject(store.get().project);
   if (result.errors.length) {
-    showMessage('Resolve validation errors before entering Play mode.');
+    showMessage({
+      text: 'Resolve validation errors before entering Play mode.',
+      errors: result.errors,
+      warnings: result.warnings,
+    });
     if (mode !== 'edit') {
       setMode('edit');
     }
@@ -89,6 +122,7 @@ fileInput.addEventListener('change', async (e) => {
   const file = e.target.files?.[0];
   if (!file) return;
   try {
+    showMessage('Importing project…');
     await importProject(store, file);
     showMessage('Imported project.');
     setMode('edit');
@@ -102,13 +136,32 @@ fileInput.addEventListener('change', async (e) => {
 
 btnExport.addEventListener('click', async () => {
   try {
+    showMessage('Preparing export…');
     await exportProject(store);
-    showMessage('Exported project JSON.');
+    showMessage('Exported project archive.');
   } catch (err) {
     console.error(err);
     showMessage('Export failed.');
   }
 });
 
-// Initial render
-setMode('edit');
+async function bootstrap() {
+  try {
+    persistenceCleanup = await setupPersistence(store, { showMessage });
+  } catch (err) {
+    console.error('Failed to initialise persistence', err);
+    persistenceCleanup = () => {};
+  }
+  setMode('edit');
+}
+
+bootstrap();
+
+window.addEventListener('beforeunload', () => {
+  if (typeof teardown === 'function') {
+    teardown();
+  }
+  if (typeof persistenceCleanup === 'function') {
+    persistenceCleanup();
+  }
+});

--- a/public/scripts/model.js
+++ b/public/scripts/model.js
@@ -27,6 +27,7 @@ export function createScene(options = {}) {
     id = newId('scene'),
     type = SceneType.INTERMEDIATE,
     image = null,
+    backgroundAudio = null,
     dialogue = [],
     choices = [],
     autoNextSceneId = null,
@@ -41,6 +42,9 @@ export function createScene(options = {}) {
     id,
     type,
     image: image ? { name: image.name ?? '', objectUrl: image.objectUrl ?? null } : null,
+    backgroundAudio: backgroundAudio
+      ? { name: backgroundAudio.name ?? '', objectUrl: backgroundAudio.objectUrl ?? null }
+      : null,
     dialogue: normalisedDialogue,
     choices: choices.slice(0, 3).map(normaliseChoice),
     autoNextSceneId: type === SceneType.END ? null : (autoNextSceneId ?? null),

--- a/public/scripts/model.js
+++ b/public/scripts/model.js
@@ -10,7 +10,13 @@ export const SceneType = Object.freeze({
 function normaliseDialogueLine(line = {}) {
   return {
     text: line.text ?? '',
-    audio: line.audio ? { name: line.audio.name ?? '', objectUrl: line.audio.objectUrl ?? null } : null,
+    audio: line.audio
+      ? {
+        name: line.audio.name ?? '',
+        objectUrl: line.audio.objectUrl ?? null,
+        blob: line.audio.blob ?? null,
+      }
+      : null,
   };
 }
 
@@ -41,9 +47,19 @@ export function createScene(options = {}) {
   return {
     id,
     type,
-    image: image ? { name: image.name ?? '', objectUrl: image.objectUrl ?? null } : null,
+    image: image
+      ? {
+        name: image.name ?? '',
+        objectUrl: image.objectUrl ?? null,
+        blob: image.blob ?? null,
+      }
+      : null,
     backgroundAudio: backgroundAudio
-      ? { name: backgroundAudio.name ?? '', objectUrl: backgroundAudio.objectUrl ?? null }
+      ? {
+        name: backgroundAudio.name ?? '',
+        objectUrl: backgroundAudio.objectUrl ?? null,
+        blob: backgroundAudio.blob ?? null,
+      }
       : null,
     dialogue: normalisedDialogue,
     choices: choices.slice(0, 3).map(normaliseChoice),

--- a/public/scripts/player/audio.js
+++ b/public/scripts/player/audio.js
@@ -118,11 +118,16 @@ export function createBackgroundAudioController({ defaultVolume = 0.4 } = {}) {
     }
   }
 
+  function getCurrentSource() {
+    return activeSrc;
+  }
+
   return {
     play,
     stop,
     teardown: stop,
     setVolume,
     setMuted,
+    getCurrentSource,
   };
 }

--- a/public/scripts/player/audio.js
+++ b/public/scripts/player/audio.js
@@ -1,3 +1,80 @@
 export function ensureAudioGate(store) {
   if (!store.get().audioGate) store.set({ audioGate: true });
 }
+
+export function createBackgroundAudioController() {
+  let activeAudio = null;
+  let activeSrc = null;
+
+  function stop() {
+    if (!activeAudio) {
+      activeSrc = null;
+      return;
+    }
+    try {
+      if (typeof activeAudio.pause === 'function') {
+        activeAudio.pause();
+      }
+    } catch (err) {
+      console.warn('Failed to pause background audio', err);
+    }
+    try {
+      activeAudio.currentTime = 0;
+    } catch (err) {
+      // ignore inability to reset currentTime
+    }
+    activeAudio = null;
+    activeSrc = null;
+  }
+
+  function play(src) {
+    if (!src) {
+      stop();
+      return;
+    }
+    if (activeSrc === src && activeAudio) {
+      if (activeAudio.paused && typeof activeAudio.play === 'function') {
+        try {
+          const attempt = activeAudio.play();
+          if (attempt?.catch) {
+            attempt.catch(() => {});
+          }
+        } catch (err) {
+          console.warn('Background audio resume failed', err);
+        }
+      }
+      return;
+    }
+
+    stop();
+
+    const audio = new Audio(src);
+    audio.loop = true;
+
+    activeAudio = audio;
+    activeSrc = src;
+
+    try {
+      const playAttempt = audio.play();
+      if (playAttempt?.catch) {
+        playAttempt.catch((err) => {
+          console.warn('Background audio playback failed', err);
+          if (activeAudio === audio) {
+            stop();
+          }
+        });
+      }
+    } catch (err) {
+      console.warn('Background audio playback failed', err);
+      if (activeAudio === audio) {
+        stop();
+      }
+    }
+  }
+
+  return {
+    play,
+    stop,
+    teardown: stop,
+  };
+}

--- a/public/scripts/player/player.js
+++ b/public/scripts/player/player.js
@@ -15,24 +15,47 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
   rightEl.appendChild(uiPanel);
 
   let currentSceneId = null;
+  let sceneHistory = [];
+  let historyIndex = -1;
   let backgroundVolume = 0.4;
   let backgroundMuted = false;
+  let defaultBackgroundSource = null;
+  let activeDialogueCleanup = null;
   const backgroundTrack = createBackgroundAudioController({ defaultVolume: backgroundVolume });
   backgroundTrack.setVolume(backgroundVolume);
 
   const unsubscribe = store.subscribe(() => {
     if (!currentSceneId) return;
     const { project } = store.get();
-    if (!project.scenes.some(scene => scene.id === currentSceneId)) {
+    syncHistoryWithProject(project);
+
+    if (!sceneHistory.length) {
+      return;
+    }
+
+    if (!currentSceneId) {
       const start = findStartScene(project);
-      currentSceneId = start?.id ?? null;
+      if (start) {
+        beginRunAt(start.id);
+      } else {
+        renderIntro();
+      }
+      return;
     }
-    if (currentSceneId) {
-      renderCurrentScene();
-    }
+
+    renderCurrentScene();
   });
 
+  function stopActiveDialogue() {
+    if (activeDialogueCleanup) {
+      const cleanupFn = activeDialogueCleanup;
+      activeDialogueCleanup = null;
+      cleanupFn();
+    }
+  }
+
   function cleanup() {
+    stopActiveDialogue();
     unsubscribe();
     backgroundTrack.teardown();
   }
@@ -41,9 +64,34 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
     return project.scenes.find(scene => scene.type === SceneType.START) ?? project.scenes[0] ?? null;
   }
 
-  function renderIntro() {
-    const { project } = store.get();
+  function findSceneById(project, sceneId) {
+    if (!sceneId) {
+      return null;
+    }
+    return project.scenes.find(scene => scene.id === sceneId) ?? null;
+  }
+
+  function getEffectiveBackgroundSource(scene) {
+    if (!scene) {
+      return null;
+    }
+    return scene.backgroundAudio?.objectUrl ?? defaultBackgroundSource ?? null;
+  }
+
+  function maybeStopBeforeScene(nextScene) {
+    const currentSource = backgroundTrack.getCurrentSource();
+    const nextSource = getEffectiveBackgroundSource(nextScene);
+    if (currentSource && nextSource && currentSource === nextSource) {
+      return;
+    }
     backgroundTrack.stop();
+  }
+
+  function renderIntro() {
+    stopActiveDialogue();
+    const { project } = store.get();
+    maybeStopBeforeScene(null);
+    resetHistory();
     stage.innerHTML = '';
     const introStage = document.createElement('div');
     introStage.className = 'stage-empty';
@@ -62,18 +110,24 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
         showMessage('No Start scene found.');
         return;
       }
-      backgroundTrack.stop();
-      currentSceneId = startScene.id;
-      renderCurrentScene();
+      beginRunAt(startScene.id);
     });
     uiPanel.append(title, startBtn);
   }
 
   function renderCurrentScene() {
+    stopActiveDialogue();
     const { project } = store.get();
-    const scene = project.scenes.find(s => s.id === currentSceneId);
+    syncHistoryWithProject(project);
+
+    if (!currentSceneId) {
+      renderIntro();
+      return;
+    }
+
+    const scene = findSceneById(project, currentSceneId);
     if (!scene) {
-      backgroundTrack.stop();
+      maybeStopBeforeScene(null);
       showMessage('Scene missing.');
       renderIntro();
       return;
@@ -81,14 +135,16 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
 
     syncBackgroundAudio(scene);
 
-    renderPlayerUI({
+    const dialogueCleanup = renderPlayerUI({
       stageEl: stage,
       uiEl: uiPanel,
       project,
       scene,
       onChoice: (nextId) => {
-        backgroundTrack.stop();
-        currentSceneId = nextId;
+        stopActiveDialogue();
+        const nextScene = findSceneById(project, nextId);
+        maybeStopBeforeScene(nextScene);
+        pushSceneToHistory(nextId);
         renderCurrentScene();
       },
       backgroundAudioControls: store.get().audioGate
@@ -106,15 +162,18 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
             },
           }
         : null,
+      historyControls: createHistoryControls(project),
     });
+
+    activeDialogueCleanup = typeof dialogueCleanup === 'function' ? dialogueCleanup : null;
   }
 
   function syncBackgroundAudio(scene) {
-    if (!scene || !store.get().audioGate) {
+    if (!store.get().audioGate) {
       backgroundTrack.stop();
       return;
     }
-    const source = scene.backgroundAudio?.objectUrl ?? null;
+    const source = getEffectiveBackgroundSource(scene);
     if (!source) {
       backgroundTrack.stop();
       return;
@@ -122,6 +181,121 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
     backgroundTrack.setVolume(backgroundVolume);
     backgroundTrack.setMuted(backgroundMuted);
     backgroundTrack.play(source);
+  }
+
+  function beginRunAt(sceneId) {
+    if (!sceneId) return;
+    const { project } = store.get();
+    const startScene = findStartScene(project);
+    defaultBackgroundSource = startScene?.backgroundAudio?.objectUrl ?? null;
+    const nextScene = findSceneById(project, sceneId);
+    maybeStopBeforeScene(nextScene);
+    sceneHistory = [sceneId];
+    historyIndex = 0;
+    currentSceneId = sceneId;
+    renderCurrentScene();
+  }
+
+  function resetHistory() {
+    sceneHistory = [];
+    historyIndex = -1;
+    currentSceneId = null;
+    defaultBackgroundSource = null;
+  }
+
+  function pushSceneToHistory(sceneId) {
+    if (!sceneId) {
+      return;
+    }
+    if (historyIndex < sceneHistory.length - 1) {
+      sceneHistory = sceneHistory.slice(0, historyIndex + 1);
+    }
+    if (sceneHistory[sceneHistory.length - 1] !== sceneId) {
+      sceneHistory.push(sceneId);
+    }
+    historyIndex = sceneHistory.length - 1;
+    currentSceneId = sceneId;
+  }
+
+  function syncHistoryWithProject(project) {
+    if (!sceneHistory.length) {
+      return;
+    }
+
+    const availableIds = new Set(project.scenes.map(scene => scene.id));
+    const filtered = sceneHistory.filter(id => availableIds.has(id));
+
+    if (!filtered.length) {
+      resetHistory();
+      return;
+    }
+
+    if (filtered.length !== sceneHistory.length) {
+      sceneHistory = filtered;
+    }
+
+    if (historyIndex >= sceneHistory.length) {
+      historyIndex = sceneHistory.length - 1;
+    }
+
+    currentSceneId = sceneHistory[historyIndex] ?? null;
+  }
+
+  function goToHistoryIndex(index) {
+    if (index < 0 || index >= sceneHistory.length) {
+      return;
+    }
+    stopActiveDialogue();
+    const { project } = store.get();
+    const nextSceneId = sceneHistory[index];
+    const nextScene = findSceneById(project, nextSceneId);
+    maybeStopBeforeScene(nextScene);
+    historyIndex = index;
+    currentSceneId = nextSceneId;
+    renderCurrentScene();
+  }
+
+  function navigateHistory(delta) {
+    goToHistoryIndex(historyIndex + delta);
+  }
+
+  function createHistoryControls(project) {
+    if (!sceneHistory.length) {
+      return null;
+    }
+
+    const entries = sceneHistory
+      .map((sceneId) => {
+        const scene = project.scenes.find(s => s.id === sceneId);
+        if (!scene) {
+          return null;
+        }
+        const fallback = scene.id || sceneId;
+        const firstLine = scene.dialogue?.[0]?.text?.trim();
+        const label = firstLine ? firstLine : fallback;
+        return { sceneId, label };
+      })
+      .filter(Boolean);
+
+    if (!entries.length) {
+      return null;
+    }
+
+    const clampedIndex = Math.max(0, Math.min(historyIndex, entries.length - 1));
+    if (clampedIndex !== historyIndex) {
+      historyIndex = clampedIndex;
+      currentSceneId = sceneHistory[historyIndex];
+    }
+
+    return {
+      entries,
+      index: historyIndex,
+      canGoBack: historyIndex > 0,
+      canGoForward: historyIndex < entries.length - 1,
+      onBack: () => navigateHistory(-1),
+      onForward: () => navigateHistory(1),
+      onJump: (index) => goToHistoryIndex(index),
+    };
   }
 
   renderIntro();

--- a/public/scripts/player/player.js
+++ b/public/scripts/player/player.js
@@ -15,7 +15,10 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
   rightEl.appendChild(uiPanel);
 
   let currentSceneId = null;
-  const backgroundTrack = createBackgroundAudioController();
+  let backgroundVolume = 0.4;
+  let backgroundMuted = false;
+  const backgroundTrack = createBackgroundAudioController({ defaultVolume: backgroundVolume });
+  backgroundTrack.setVolume(backgroundVolume);
 
   const unsubscribe = store.subscribe(() => {
     if (!currentSceneId) return;
@@ -88,6 +91,21 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
         currentSceneId = nextId;
         renderCurrentScene();
       },
+      backgroundAudioControls: store.get().audioGate
+        ? {
+            volume: backgroundVolume,
+            muted: backgroundMuted,
+            onVolumeChange: (value) => {
+              backgroundVolume = value;
+              backgroundTrack.setVolume(value);
+            },
+            onToggleMute: () => {
+              backgroundMuted = !backgroundMuted;
+              backgroundTrack.setMuted(backgroundMuted);
+              return backgroundMuted;
+            },
+          }
+        : null,
     });
   }
 
@@ -101,6 +119,8 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
       backgroundTrack.stop();
       return;
     }
+    backgroundTrack.setVolume(backgroundVolume);
+    backgroundTrack.setMuted(backgroundMuted);
     backgroundTrack.play(source);
   }
 

--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -1,6 +1,6 @@
 import { SceneType } from '../model.js';
 
-export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice }) {
+export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgroundAudioControls = null }) {
   stageEl.innerHTML = '';
   uiEl.innerHTML = '';
 
@@ -21,6 +21,68 @@ export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice }) {
     emptyStage.className = 'stage-empty';
     emptyStage.textContent = 'No stage image';
     stageEl.appendChild(emptyStage);
+  }
+
+  if (backgroundAudioControls) {
+    const bgControls = document.createElement('div');
+    bgControls.className = 'background-audio-controls';
+
+    const heading = document.createElement('h4');
+    heading.textContent = 'Background music';
+    bgControls.appendChild(heading);
+
+    const volumeWrapper = document.createElement('div');
+    volumeWrapper.className = 'background-volume';
+
+    const volumeLabel = document.createElement('label');
+    volumeLabel.textContent = 'Background music volume';
+
+    const volumeSlider = document.createElement('input');
+    volumeSlider.type = 'range';
+    volumeSlider.min = '0';
+    volumeSlider.max = '1';
+    volumeSlider.step = '0.05';
+    volumeSlider.value = String(backgroundAudioControls.volume ?? 0);
+    volumeSlider.setAttribute('aria-label', 'Background music volume');
+    volumeSlider.disabled = Boolean(backgroundAudioControls.muted);
+
+    const volumeValue = document.createElement('span');
+    volumeValue.className = 'background-volume-value';
+    const initialVolume = Number(backgroundAudioControls.volume ?? 0);
+    volumeValue.textContent = `${Math.round(initialVolume * 100)}%`;
+
+    volumeSlider.addEventListener('input', event => {
+      const value = Number(event.target.value);
+      backgroundAudioControls.volume = value;
+      volumeValue.textContent = `${Math.round(value * 100)}%`;
+      backgroundAudioControls.onVolumeChange?.(value);
+    });
+
+    volumeLabel.appendChild(volumeSlider);
+    volumeWrapper.append(volumeLabel, volumeValue);
+    bgControls.appendChild(volumeWrapper);
+
+    const muteButton = document.createElement('button');
+    muteButton.type = 'button';
+
+    const updateMuteLabel = (muted) => {
+      muteButton.textContent = muted ? 'Unmute background music' : 'Mute background music';
+      muteButton.setAttribute('aria-pressed', muted ? 'true' : 'false');
+      muteButton.setAttribute('aria-label', muted ? 'Unmute background music' : 'Mute background music');
+      volumeSlider.disabled = muted;
+    };
+
+    updateMuteLabel(Boolean(backgroundAudioControls.muted));
+
+    muteButton.addEventListener('click', () => {
+      const nextMuted = backgroundAudioControls.onToggleMute?.();
+      const resolved = typeof nextMuted === 'boolean' ? nextMuted : !backgroundAudioControls.muted;
+      backgroundAudioControls.muted = resolved;
+      updateMuteLabel(resolved);
+    });
+
+    bgControls.appendChild(muteButton);
+    uiEl.appendChild(bgControls);
   }
 
   const dialogueBox = document.createElement('div');

--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -1,14 +1,279 @@
 import { SceneType } from '../model.js';
 
-export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgroundAudioControls = null }) {
+function createDialogueAudioController() {
+  let audio = null;
+  let activeMode = null;
+  let endedHandler = null;
+  let errorHandler = null;
+
+  const ensureAudio = () => {
+    if (!audio) {
+      audio = new Audio();
+    }
+    return audio;
+  };
+
+  const detachListeners = () => {
+    if (!audio) {
+      return;
+    }
+    if (endedHandler) {
+      audio.removeEventListener('ended', endedHandler);
+      endedHandler = null;
+    }
+    if (errorHandler) {
+      audio.removeEventListener('error', errorHandler);
+      errorHandler = null;
+    }
+  };
+
+  const resetElement = () => {
+    if (!audio) {
+      return;
+    }
+    detachListeners();
+    try {
+      audio.pause();
+    } catch (err) {
+      // Ignore pause failures.
+    }
+    try {
+      audio.currentTime = 0;
+    } catch (err) {
+      // Ignore reset failures (e.g., when audio is not seekable yet).
+    }
+    // Clearing the src releases resources without destroying the element.
+    if (audio.src) {
+      if (typeof audio.removeAttribute === 'function') {
+        audio.removeAttribute('src');
+      } else {
+        audio.src = '';
+      }
+      if (typeof audio.load === 'function') {
+        audio.load();
+      }
+    }
+  };
+
+  const stop = ({ reason = 'cancel', error = null } = {}) => {
+    if (!activeMode) {
+      return;
+    }
+
+    const mode = activeMode;
+
+    if (mode.type === 'sequence' && mode.currentEntry) {
+      mode.handlers?.onLineEnd?.(mode.currentEntry, mode.currentIndex);
+      mode.currentEntry = null;
+    }
+
+    activeMode = null;
+    resetElement();
+
+    if (reason === 'complete') {
+      mode.handlers?.onComplete?.();
+    } else if (reason === 'error') {
+      mode.handlers?.onError?.(error);
+    } else {
+      mode.handlers?.onCancel?.();
+    }
+  };
+
+  const playClip = ({ src, onComplete, onCancel, onError }) => {
+    if (!src) {
+      return;
+    }
+
+    stop();
+
+    const handlers = {
+      onComplete,
+      onCancel,
+      onError,
+    };
+
+    const mode = {
+      type: 'clip',
+      handlers,
+    };
+
+    activeMode = mode;
+
+    const element = ensureAudio();
+
+    endedHandler = () => {
+      stop({ reason: 'complete' });
+    };
+
+    errorHandler = (event) => {
+      const err = event?.error ?? event;
+      stop({ reason: 'error', error: err });
+    };
+
+    element.addEventListener('ended', endedHandler);
+    element.addEventListener('error', errorHandler);
+
+    element.src = src;
+
+    try {
+      element.currentTime = 0;
+    } catch (err) {
+      // Ignore reset failures.
+    }
+
+    try {
+      const playAttempt = element.play();
+      if (playAttempt?.catch) {
+        playAttempt.catch(err => {
+          if (activeMode === mode) {
+            stop({ reason: 'error', error: err });
+          }
+        });
+      }
+    } catch (err) {
+      stop({ reason: 'error', error: err });
+    }
+  };
+
+  const playSequence = (entries, handlers = {}) => {
+    stop();
+
+    if (!entries?.length) {
+      handlers.onComplete?.();
+      return;
+    }
+
+    const mode = {
+      type: 'sequence',
+      handlers,
+      currentIndex: 0,
+      currentEntry: null,
+      entries,
+    };
+
+    activeMode = mode;
+
+    const element = ensureAudio();
+
+    const playCurrent = () => {
+      if (activeMode !== mode) {
+        return;
+      }
+
+      if (mode.currentIndex >= mode.entries.length) {
+        stop({ reason: 'complete' });
+        return;
+      }
+
+      const entry = mode.entries[mode.currentIndex];
+      mode.currentEntry = entry;
+      handlers.onLineStart?.(entry, mode.currentIndex);
+
+      detachListeners();
+
+      endedHandler = () => {
+        handlers.onLineEnd?.(entry, mode.currentIndex);
+        mode.currentEntry = null;
+        mode.currentIndex += 1;
+        playCurrent();
+      };
+
+      errorHandler = (event) => {
+        const err = event?.error ?? event;
+        handlers.onLineEnd?.(entry, mode.currentIndex);
+        mode.currentEntry = null;
+        stop({ reason: 'error', error: err });
+      };
+
+      element.addEventListener('ended', endedHandler);
+      element.addEventListener('error', errorHandler);
+
+      element.src = entry.src;
+
+      try {
+        element.currentTime = 0;
+      } catch (err) {
+        // Ignore reset failures.
+      }
+
+      try {
+        const playAttempt = element.play();
+        if (playAttempt?.catch) {
+          playAttempt.catch(err => {
+            if (activeMode === mode) {
+              handlers.onLineEnd?.(entry, mode.currentIndex);
+              mode.currentEntry = null;
+              stop({ reason: 'error', error: err });
+            }
+          });
+        }
+      } catch (err) {
+        handlers.onLineEnd?.(entry, mode.currentIndex);
+        mode.currentEntry = null;
+        stop({ reason: 'error', error: err });
+      }
+    };
+
+    playCurrent();
+  };
+
+  return {
+    playClip,
+    playSequence,
+    stop: () => stop(),
+  };
+}
+
+export function renderPlayerUI({
+  stageEl,
+  uiEl,
+  project,
+  scene,
+  onChoice,
+  backgroundAudioControls = null,
+  historyControls = null,
+}) {
   stageEl.innerHTML = '';
   uiEl.innerHTML = '';
+
+  const dialogueAudio = createDialogueAudioController();
+
+  const lineButtons = new Map();
+  let activeLineIndex = null;
+
+  const setLineButtonState = (index, active) => {
+    const button = lineButtons.get(index);
+    if (!button) {
+      return;
+    }
+
+    if (active) {
+      if (activeLineIndex !== null && activeLineIndex !== index) {
+        setLineButtonState(activeLineIndex, false);
+      }
+      activeLineIndex = index;
+      button.textContent = '⏹ Stop line';
+      button.setAttribute('aria-pressed', 'true');
+    } else {
+      if (activeLineIndex === index) {
+        activeLineIndex = null;
+      }
+      button.textContent = '▶️ Play line';
+      button.setAttribute('aria-pressed', 'false');
+    }
+  };
+
+  const resetAllLines = () => {
+    if (activeLineIndex !== null) {
+      setLineButtonState(activeLineIndex, false);
+    }
+  };
 
   if (!scene) {
     const placeholder = document.createElement('p');
     placeholder.textContent = 'No scene selected.';
     uiEl.appendChild(placeholder);
-    return;
+    return () => dialogueAudio.stop();
   }
 
   if (scene.image?.objectUrl) {
@@ -85,6 +350,71 @@ export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgr
     uiEl.appendChild(bgControls);
   }
 
+  if (historyControls?.entries?.length) {
+    const historyWrapper = document.createElement('div');
+    historyWrapper.className = 'player-history';
+
+    const historyTitle = document.createElement('h4');
+    historyTitle.className = 'player-history-title';
+    historyTitle.textContent = 'Story history';
+    historyWrapper.appendChild(historyTitle);
+
+    const navControls = document.createElement('div');
+    navControls.className = 'player-history-nav';
+
+    const backButton = document.createElement('button');
+    backButton.type = 'button';
+    backButton.className = 'player-history-back';
+    backButton.textContent = '← Back';
+    backButton.disabled = !historyControls.canGoBack;
+    backButton.setAttribute('aria-label', 'Go to previous scene');
+    if (historyControls.onBack) {
+      backButton.addEventListener('click', () => historyControls.onBack());
+    }
+
+    const forwardButton = document.createElement('button');
+    forwardButton.type = 'button';
+    forwardButton.className = 'player-history-forward';
+    forwardButton.textContent = 'Forward →';
+    forwardButton.disabled = !historyControls.canGoForward;
+    forwardButton.setAttribute('aria-label', 'Go to next scene');
+    if (historyControls.onForward) {
+      forwardButton.addEventListener('click', () => historyControls.onForward());
+    }
+
+    navControls.appendChild(backButton);
+    navControls.appendChild(forwardButton);
+    historyWrapper.appendChild(navControls);
+
+    const historyList = document.createElement('ol');
+    historyList.className = 'player-history-list';
+    historyList.setAttribute('aria-label', 'Visited scenes');
+
+    historyControls.entries.forEach((entry, index) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'player-history-entry';
+      button.textContent = entry.label || entry.sceneId;
+      if (button.dataset) {
+        button.dataset.sceneId = entry.sceneId;
+      }
+
+      if (index === historyControls.index) {
+        button.disabled = true;
+        button.setAttribute('aria-current', 'step');
+      } else if (historyControls.onJump) {
+        button.addEventListener('click', () => historyControls.onJump(index));
+      }
+
+      item.appendChild(button);
+      historyList.appendChild(item);
+    });
+
+    historyWrapper.appendChild(historyList);
+    uiEl.appendChild(historyWrapper);
+  }
+
   const dialogueBox = document.createElement('div');
   dialogueBox.className = 'player-dialogue';
 
@@ -92,125 +422,66 @@ export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgr
     .map((line, index) => ({ line, index }))
     .filter(entry => entry.line.audio?.objectUrl);
 
-  let activeSequence = null;
+  let playAllActive = false;
+
+  const setPlayAllState = (active) => {
+    playAllActive = active;
+    if (!playAllButton) {
+      return;
+    }
+    playAllButton.textContent = active ? '⏹ Stop playback' : '▶️ Play all';
+    playAllButton.setAttribute('aria-pressed', active ? 'true' : 'false');
+    playAllButton.disabled = false;
+  };
+
+  let playAllButton = null;
 
   if (audioEntries.length) {
-    const playAllButton = document.createElement('button');
+    playAllButton = document.createElement('button');
     playAllButton.type = 'button';
     playAllButton.className = 'audio-play-all';
     playAllButton.textContent = '▶️ Play all';
     playAllButton.setAttribute('aria-label', 'Play all dialogue audio');
+    playAllButton.setAttribute('aria-pressed', 'false');
 
-    const resetButtonState = () => {
-      playAllButton.textContent = '▶️ Play all';
-      playAllButton.disabled = false;
-    };
-
-    const startSequence = () => {
-      let cancelled = false;
-      let currentIndex = 0;
-      let activeCleanup = null;
-      let sequenceActive = true;
-
-      const handleFailure = err => {
-        console.warn('Audio playback failed', err);
-        finishSequence();
-      };
-
-      const finishSequence = () => {
-        if (activeCleanup) {
-          activeCleanup();
-          activeCleanup = null;
-        }
-        sequenceActive = false;
-        resetButtonState();
-        activeSequence = null;
-      };
-
-      const playNext = () => {
-        if (cancelled) {
-          finishSequence();
-          return;
-        }
-
-        const entry = audioEntries[currentIndex];
-        if (!entry) {
-          finishSequence();
-          return;
-        }
-
-        if (activeCleanup) {
-          activeCleanup();
-          activeCleanup = null;
-        }
-
-        const audio = new Audio(entry.line.audio.objectUrl);
-
-        const cleanup = () => {
-          audio.removeEventListener('ended', onEnded);
-          audio.removeEventListener('error', onError);
-          if (typeof audio.pause === 'function') {
-            audio.pause();
-          }
-          audio.currentTime = 0;
-          activeCleanup = null;
-        };
-
-        const onEnded = () => {
-          cleanup();
-          currentIndex += 1;
-          playNext();
-        };
-
-        const onError = event => {
-          cleanup();
-          handleFailure(event?.error ?? event);
-        };
-
-        activeCleanup = cleanup;
-
-        audio.addEventListener('ended', onEnded);
-        audio.addEventListener('error', onError);
-
-        try {
-          const playAttempt = audio.play();
-          if (playAttempt?.catch) {
-            playAttempt.catch(err => {
-              cleanup();
-              handleFailure(err);
-            });
-          }
-        } catch (err) {
-          cleanup();
-          handleFailure(err);
-        }
-      };
-
-      const sequence = {
-        stop() {
-          if (cancelled) {
-            return;
-          }
-          cancelled = true;
-          finishSequence();
-        },
-      };
-
-      playAllButton.textContent = '⏹ Stop playback';
-      playAllButton.disabled = false;
-
-      playNext();
-
-      return sequenceActive ? sequence : null;
+    const revertPlayAll = () => {
+      setPlayAllState(false);
+      resetAllLines();
     };
 
     playAllButton.addEventListener('click', () => {
-      if (activeSequence) {
-        activeSequence.stop();
+      const wasActive = playAllActive;
+      dialogueAudio.stop();
+      if (wasActive) {
         return;
       }
 
-      activeSequence = startSequence();
+      setPlayAllState(true);
+
+      dialogueAudio.playSequence(
+        audioEntries.map(entry => ({
+          src: entry.line.audio.objectUrl,
+          index: entry.index,
+        })),
+        {
+          onLineStart: (entry) => {
+            setLineButtonState(entry.index, true);
+          },
+          onLineEnd: (entry) => {
+            setLineButtonState(entry.index, false);
+          },
+          onComplete: () => {
+            revertPlayAll();
+          },
+          onCancel: () => {
+            revertPlayAll();
+          },
+          onError: (error) => {
+            console.warn('Audio playback failed', error);
+            revertPlayAll();
+          },
+        },
+      );
     });
 
     dialogueBox.appendChild(playAllButton);
@@ -229,13 +500,32 @@ export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgr
       playButton.type = 'button';
       playButton.className = 'audio-play';
       playButton.textContent = '▶️ Play line';
-      playButton.addEventListener('click', async () => {
-        try {
-          const audio = new Audio(line.audio.objectUrl);
-          await audio.play();
-        } catch (err) {
-          console.warn('Audio playback failed', err);
+      playButton.setAttribute('aria-pressed', 'false');
+
+      lineButtons.set(index, playButton);
+
+      playButton.addEventListener('click', () => {
+        const wasActive = activeLineIndex === index;
+        dialogueAudio.stop();
+        if (wasActive) {
+          return;
         }
+
+        setLineButtonState(index, true);
+
+        dialogueAudio.playClip({
+          src: line.audio.objectUrl,
+          onComplete: () => {
+            setLineButtonState(index, false);
+          },
+          onCancel: () => {
+            setLineButtonState(index, false);
+          },
+          onError: (error) => {
+            console.warn('Audio playback failed', error);
+            setLineButtonState(index, false);
+          },
+        });
       });
       lineContainer.appendChild(playButton);
     }
@@ -297,4 +587,8 @@ export function renderPlayerUI({ stageEl, uiEl, project, scene, onChoice, backgr
   }
 
   uiEl.appendChild(choiceBox);
+
+  return () => {
+    dialogueAudio.stop();
+  };
 }

--- a/public/scripts/storage.js
+++ b/public/scripts/storage.js
@@ -1,68 +1,562 @@
-import { createProject, createScene, createChoice, SceneType } from './model.js';
+import { createProject, createScene, SceneType } from './model.js';
+import { zip, unzip } from './utils/zip.js';
 
-// Import/Export (JSON). IndexedDB stubbed for now.
-export async function importProject(store, file) {
-  const text = await file.text();
-  const json = JSON.parse(text);
-  const sceneData = Array.isArray(json.scenes) ? json.scenes.slice(0, 20) : [];
-  const base = createProject({ ...json, scenes: sceneData });
+const DB_NAME = 'roleplayscene';
+const DB_VERSION = 1;
+const PROJECT_STORE = 'project';
+const PROJECT_KEY = 'snapshot';
+const SAVE_DEBOUNCE_MS = 500;
+const ARCHIVE_MANIFEST_VERSION = 1;
 
-  const cleanedScenes = base.scenes.map(scene => {
-    const imported = createScene(scene);
-    imported.image = null;
-    imported.backgroundAudio = null;
-    imported.dialogue = imported.dialogue.map(line => ({ text: line.text || '', audio: null }));
-    imported.choices = imported.choices.map(choice => createChoice({
-      id: choice.id,
-      label: choice.label,
-      nextSceneId: choice.nextSceneId ?? null,
-    }));
-    const candidateAutoNext = scene.autoNextSceneId ?? null;
-    imported.autoNextSceneId = imported.type === SceneType.END ? null : candidateAutoNext;
-    return imported;
+function noop() {}
+
+function isIndexedDBAvailable() {
+  return typeof globalThis !== 'undefined'
+    && typeof globalThis.indexedDB !== 'undefined';
+}
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    if (!isIndexedDBAvailable()) {
+      reject(new Error('IndexedDB is unavailable'));
+      return;
+    }
+    const request = globalThis.indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(PROJECT_STORE)) {
+        db.createObjectStore(PROJECT_STORE);
+      }
+    };
+    request.onerror = () => {
+      reject(request.error || new Error('Failed to open IndexedDB'));
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+  });
+}
+
+function withStore(db, mode, fn) {
+  return new Promise((resolve, reject) => {
+    try {
+      const tx = db.transaction(PROJECT_STORE, mode);
+      const store = tx.objectStore(PROJECT_STORE);
+      const request = fn(store);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error || new Error('IndexedDB request failed'));
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+function readSnapshot(db) {
+  return withStore(db, 'readonly', store => store.get(PROJECT_KEY));
+}
+
+function writeSnapshot(db, data) {
+  return withStore(db, 'readwrite', store => store.put(data, PROJECT_KEY));
+}
+
+function safeCreateObjectURL(blob) {
+  if (!blob || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    return null;
+  }
+  try {
+    return URL.createObjectURL(blob);
+  } catch (err) {
+    console.warn('Failed to create object URL from blob', err);
+    return null;
+  }
+}
+
+function safeRevokeObjectURL(url) {
+  if (!url || typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+    return;
+  }
+  try {
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    console.warn('Failed to revoke object URL', err);
+  }
+}
+
+function sanitizeFilename(name, fallback) {
+  const fallbackValue = fallback || 'roleplay';
+  if (!name) return fallbackValue;
+  const trimmed = String(name).trim();
+  if (!trimmed) return fallbackValue;
+  const safe = trimmed
+    .replace(/[\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, '-');
+  return safe.slice(0, 128) || fallbackValue;
+}
+
+function sanitizePathSegment(segment, fallback) {
+  const fallbackValue = fallback || 'item';
+  if (!segment) return fallbackValue;
+  const safe = String(segment)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return safe || fallbackValue;
+}
+
+function getExtension(name) {
+  if (!name) return '';
+  const index = String(name).lastIndexOf('.');
+  if (index === -1) return '';
+  return String(name).slice(index);
+}
+
+function ensureUniquePath(basePath, used) {
+  let candidate = basePath;
+  let counter = 1;
+  while (used.has(candidate)) {
+    const lastSlash = basePath.lastIndexOf('/');
+    const dir = lastSlash >= 0 ? basePath.slice(0, lastSlash + 1) : '';
+    const file = lastSlash >= 0 ? basePath.slice(lastSlash + 1) : basePath;
+    const dotIndex = file.lastIndexOf('.');
+    const name = dotIndex >= 0 ? file.slice(0, dotIndex) : file;
+    const ext = dotIndex >= 0 ? file.slice(dotIndex) : '';
+    candidate = `${dir}${name}-${counter}${ext}`;
+    counter += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+function collectAsset({
+  asset,
+  sceneId,
+  sceneIndex,
+  kind,
+  itemIndex = null,
+  usedPaths,
+  binaries,
+}) {
+  if (!asset) return null;
+  const name = asset.name ?? '';
+  const blob = asset.blob ?? null;
+  if (!blob) {
+    return { name, type: '', size: 0, path: null };
+  }
+  const sceneSegment = sanitizePathSegment(sceneId, `scene-${sceneIndex + 1}`);
+  const baseName = itemIndex == null ? kind : `${kind}-${itemIndex + 1}`;
+  const ext = getExtension(name) || '.bin';
+  const basePath = `media/${sceneSegment}/${baseName}${ext}`;
+  const path = ensureUniquePath(basePath, usedPaths);
+  binaries.push({ path, blob });
+  const type = blob.type || 'application/octet-stream';
+  const size = typeof blob.size === 'number' ? blob.size : 0;
+  return { name, type, size, path };
+}
+
+function buildManifest(snapshot) {
+  if (!snapshot) return { manifest: null, binaries: [] };
+  const binaries = [];
+  const usedPaths = new Set();
+  const manifest = {
+    meta: { ...snapshot.meta },
+    scenes: snapshot.scenes.map((scene, sceneIndex) => {
+      const sceneId = scene.id || `scene-${sceneIndex + 1}`;
+      const dialogue = Array.isArray(scene.dialogue) ? scene.dialogue : [];
+      return {
+        id: scene.id,
+        type: scene.type,
+        image: collectAsset({
+          asset: scene.image,
+          sceneId,
+          sceneIndex,
+          kind: 'image',
+          usedPaths,
+          binaries,
+        }),
+        backgroundAudio: collectAsset({
+          asset: scene.backgroundAudio,
+          sceneId,
+          sceneIndex,
+          kind: 'background',
+          usedPaths,
+          binaries,
+        }),
+        dialogue: dialogue.map((line, lineIndex) => ({
+          text: line.text ?? '',
+          audio: collectAsset({
+            asset: line.audio,
+            sceneId,
+            sceneIndex,
+            kind: 'dialogue',
+            itemIndex: lineIndex,
+            usedPaths,
+            binaries,
+          }),
+        })),
+        choices: Array.isArray(scene.choices)
+          ? scene.choices.map(choice => ({
+              id: choice.id,
+              label: choice.label,
+              nextSceneId: choice.nextSceneId ?? null,
+            }))
+          : [],
+        autoNextSceneId: scene.autoNextSceneId ?? null,
+        notes: scene.notes ?? '',
+      };
+    }),
+    assets: Array.isArray(snapshot.assets) ? snapshot.assets.slice() : [],
+  };
+  return { manifest, binaries };
+}
+
+function restoreAsset(manifestAsset, files) {
+  if (!manifestAsset) return null;
+  const name = manifestAsset.name ?? '';
+  const path = manifestAsset.path ?? null;
+  if (path && files[path]) {
+    const type = manifestAsset.type || 'application/octet-stream';
+    const blob = new Blob([files[path]], { type });
+    return { name, blob };
+  }
+  return { name, blob: null };
+}
+
+function manifestToSerialized(manifest, files) {
+  if (!manifest) return null;
+  const scenes = Array.isArray(manifest.scenes) ? manifest.scenes.slice(0, 20) : [];
+  return {
+    meta: { ...manifest.meta },
+    scenes: scenes.map(scene => {
+      const dialogue = Array.isArray(scene.dialogue) ? scene.dialogue : [];
+      return {
+        id: scene.id,
+        type: scene.type,
+        image: restoreAsset(scene.image, files),
+        backgroundAudio: restoreAsset(scene.backgroundAudio, files),
+        dialogue: dialogue.map(line => ({
+          text: line.text ?? '',
+          audio: restoreAsset(line.audio, files),
+        })),
+        choices: Array.isArray(scene.choices)
+          ? scene.choices.map(choice => ({
+              id: choice.id,
+              label: choice.label,
+              nextSceneId: choice.nextSceneId ?? null,
+            }))
+          : [],
+        autoNextSceneId: scene.autoNextSceneId ?? null,
+        notes: scene.notes ?? '',
+      };
+    }),
+    assets: Array.isArray(manifest.assets) ? manifest.assets.slice() : [],
+  };
+}
+
+export async function createProjectArchive(project) {
+  if (!project) {
+    throw new Error('Cannot export empty project');
+  }
+  const snapshot = serializeProject(project);
+  if (!snapshot) {
+    throw new Error('Failed to serialise project');
+  }
+  const { manifest, binaries } = buildManifest(snapshot);
+  const encoder = new TextEncoder();
+  const payload = {
+    manifestVersion: ARCHIVE_MANIFEST_VERSION,
+    project: manifest,
+  };
+  const entries = {
+    'project.json': encoder.encode(JSON.stringify(payload, null, 2)),
+  };
+  for (const { path, blob } of binaries) {
+    const buffer = await blob.arrayBuffer();
+    entries[path] = new Uint8Array(buffer);
+  }
+  const archiveData = await zip(entries);
+  return { archiveData, payload };
+}
+
+export function revokeProjectObjectUrls(project) {
+  if (!project || !Array.isArray(project.scenes)) return;
+  project.scenes.forEach(scene => {
+    if (scene.image?.objectUrl) {
+      safeRevokeObjectURL(scene.image.objectUrl);
+    }
+    if (scene.backgroundAudio?.objectUrl) {
+      safeRevokeObjectURL(scene.backgroundAudio.objectUrl);
+    }
+    if (Array.isArray(scene.dialogue)) {
+      scene.dialogue.forEach(line => {
+        if (line.audio?.objectUrl) {
+          safeRevokeObjectURL(line.audio.objectUrl);
+        }
+      });
+    }
+  });
+}
+
+export function serializeProject(project) {
+  if (!project) return null;
+  const scenes = Array.isArray(project.scenes) ? project.scenes.slice(0, 20) : [];
+  return {
+    meta: { ...project.meta },
+    scenes: scenes.map(scene => {
+      const dialogue = Array.isArray(scene.dialogue) ? scene.dialogue : [];
+      const choices = Array.isArray(scene.choices) ? scene.choices : [];
+      return {
+        id: scene.id,
+        type: scene.type,
+        image: scene.image ? { name: scene.image.name ?? '', blob: scene.image.blob ?? null } : null,
+        backgroundAudio: scene.backgroundAudio
+          ? { name: scene.backgroundAudio.name ?? '', blob: scene.backgroundAudio.blob ?? null }
+          : null,
+        dialogue: dialogue.map(line => ({
+          text: line.text ?? '',
+          audio: line.audio
+            ? { name: line.audio.name ?? '', blob: line.audio.blob ?? null }
+            : null,
+        })),
+        choices: choices.map(choice => ({
+          id: choice.id,
+          label: choice.label,
+          nextSceneId: choice.nextSceneId ?? null,
+        })),
+        autoNextSceneId: scene.autoNextSceneId ?? null,
+        notes: scene.notes ?? '',
+      };
+    }),
+    assets: Array.isArray(project.assets) ? project.assets.slice() : [],
+  };
+}
+
+export function hydrateProject(serialized, { previousProject = null } = {}) {
+  if (!serialized) {
+    return createProject();
+  }
+
+  if (previousProject) {
+    revokeProjectObjectUrls(previousProject);
+  }
+
+  const scenes = Array.isArray(serialized.scenes) ? serialized.scenes : [];
+  const preparedScenes = scenes.map(scene => {
+    const imageBlob = scene.image?.blob ?? null;
+    const bgBlob = scene.backgroundAudio?.blob ?? null;
+    const dialogue = Array.isArray(scene.dialogue) ? scene.dialogue : [];
+    return {
+      id: scene.id,
+      type: scene.type ?? SceneType.INTERMEDIATE,
+      image: scene.image
+        ? {
+          name: scene.image.name ?? '',
+          blob: imageBlob,
+          objectUrl: imageBlob ? safeCreateObjectURL(imageBlob) : null,
+        }
+        : null,
+      backgroundAudio: scene.backgroundAudio
+        ? {
+          name: scene.backgroundAudio.name ?? '',
+          blob: bgBlob,
+          objectUrl: bgBlob ? safeCreateObjectURL(bgBlob) : null,
+        }
+        : null,
+      dialogue: dialogue.map(line => {
+        const audioBlob = line.audio?.blob ?? null;
+        return {
+          text: line.text ?? '',
+          audio: line.audio
+            ? {
+              name: line.audio.name ?? '',
+              blob: audioBlob,
+              objectUrl: audioBlob ? safeCreateObjectURL(audioBlob) : null,
+            }
+            : null,
+        };
+      }),
+      choices: Array.isArray(scene.choices) ? scene.choices.map(choice => ({
+        id: choice.id,
+        label: choice.label ?? '',
+        nextSceneId: choice.nextSceneId ?? null,
+      })) : [],
+      autoNextSceneId: scene.autoNextSceneId ?? null,
+      notes: scene.notes ?? '',
+    };
   });
 
-  const project = {
-    meta: { ...base.meta },
-    scenes: cleanedScenes,
-    assets: [],
-  };
+  return createProject({
+    meta: serialized.meta,
+    scenes: preparedScenes.map(scene => createScene(scene)),
+    assets: Array.isArray(serialized.assets) ? serialized.assets.slice() : [],
+  });
+}
 
-  store.set({ project });
+async function reseedPersistence(project) {
+  if (!project || !isIndexedDBAvailable()) return;
+  const snapshot = serializeProject(project);
+  if (!snapshot) return;
+  let db;
+  try {
+    db = await openDatabase();
+    await writeSnapshot(db, snapshot);
+  } catch (err) {
+    console.warn('Failed to reseed IndexedDB after manual import/export', err);
+  } finally {
+    if (db) db.close();
+  }
+}
+
+export async function setupPersistence(store, { showMessage = noop } = {}) {
+  if (!isIndexedDBAvailable()) {
+    if (typeof showMessage === 'function') {
+      showMessage('Autosave disabled: IndexedDB not supported.');
+    }
+    return noop;
+  }
+
+  let db;
+  try {
+    db = await openDatabase();
+  } catch (err) {
+    console.error('Failed to open IndexedDB', err);
+    if (typeof showMessage === 'function') {
+      showMessage('Autosave disabled: unable to open browser storage.');
+    }
+    return noop;
+  }
+
+  let disabled = false;
+  let applyingSnapshot = false;
+  let debounceHandle = null;
+
+  const notify = typeof showMessage === 'function' ? showMessage : noop;
+
+  async function loadSnapshot() {
+    try {
+      const snapshot = await readSnapshot(db);
+      if (snapshot) {
+        applyingSnapshot = true;
+        try {
+          const hydrated = hydrateProject(snapshot, { previousProject: store.get().project });
+          store.set({ project: hydrated });
+        } finally {
+          applyingSnapshot = false;
+        }
+      }
+    } catch (err) {
+      console.error('Failed to read persisted project', err);
+      notify('Autosave disabled: unable to read saved project.');
+      disabled = true;
+    }
+  }
+
+  await loadSnapshot();
+
+  async function persistNow() {
+    if (disabled) return;
+    try {
+      const { project } = store.get();
+      await writeSnapshot(db, serializeProject(project));
+    } catch (err) {
+      console.error('Failed to persist project', err);
+      if (!disabled) {
+        notify('Autosave disabled: storage error.');
+      }
+      disabled = true;
+    }
+  }
+
+  function scheduleSave() {
+    if (disabled || applyingSnapshot) return;
+    if (debounceHandle) {
+      clearTimeout(debounceHandle);
+    }
+    debounceHandle = setTimeout(() => {
+      debounceHandle = null;
+      persistNow().catch(err => {
+        console.error('Autosave failed', err);
+      });
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  const unsubscribe = store.subscribe(() => {
+    scheduleSave();
+  });
+
+  return () => {
+    if (debounceHandle) {
+      clearTimeout(debounceHandle);
+      debounceHandle = null;
+    }
+    unsubscribe();
+    if (db) {
+      db.close();
+    }
+  };
+}
+
+export async function importProject(store, file) {
+  const previous = store.get().project;
+  const name = file?.name ? String(file.name).toLowerCase() : '';
+  const mime = file?.type ? String(file.type).toLowerCase() : '';
+  const isZip = name.endsWith('.zip') || mime === 'application/zip' || mime === 'application/x-zip-compressed';
+
+  if (isZip) {
+    const buffer = new Uint8Array(await file.arrayBuffer());
+    const unpacked = await unzip(buffer);
+    const projectEntry = unpacked['project.json'];
+    if (!projectEntry) {
+      throw new Error('Archive is missing project.json');
+    }
+    const decoder = new TextDecoder();
+    const parsed = JSON.parse(decoder.decode(projectEntry));
+    const manifestVersion = parsed.manifestVersion ?? 0;
+    const manifest = manifestVersion ? parsed.project : parsed;
+    const files = { ...unpacked };
+    delete files['project.json'];
+    if (!manifest || typeof manifest !== 'object') {
+      throw new Error('Archive manifest missing project data');
+    }
+    const serialized = manifestToSerialized(manifest, files);
+    if (!serialized) {
+      throw new Error('Archive manifest invalid');
+    }
+    const hydrated = hydrateProject(serialized, { previousProject: previous });
+    store.set({ project: hydrated });
+    await reseedPersistence(hydrated);
+    return;
+  }
+
+  const text = await file.text();
+  const json = JSON.parse(text);
+  const scenes = Array.isArray(json.scenes) ? json.scenes.slice(0, 20) : [];
+  const serialized = {
+    meta: { ...json.meta },
+    scenes,
+    assets: Array.isArray(json.assets) ? json.assets.slice() : [],
+  };
+  const hydrated = hydrateProject(serialized, { previousProject: previous });
+  store.set({ project: hydrated });
+  await reseedPersistence(hydrated);
 }
 
 export async function exportProject(store) {
-  const data = store.get().project;
-  const serialised = {
-    meta: { ...data.meta },
-    scenes: data.scenes.map(scene => ({
-      id: scene.id,
-      type: scene.type,
-      image: scene.image ? { name: scene.image.name || '' } : null,
-      backgroundAudio: scene.backgroundAudio ? { name: scene.backgroundAudio.name || '' } : null,
-      dialogue: scene.dialogue.map(line => ({
-        text: line.text,
-        audio: line.audio ? { name: line.audio.name || '' } : null,
-      })),
-      choices: scene.choices.map(choice => ({
-        id: choice.id,
-        label: choice.label,
-        nextSceneId: choice.nextSceneId ?? null,
-      })),
-      autoNextSceneId: scene.autoNextSceneId ?? null,
-      notes: scene.notes || '',
-    })),
-    assets: [],
-  };
-
-  const json = JSON.stringify(serialised, null, 2);
-  const blob = new Blob([json], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
+  const project = store.get().project;
+  const { archiveData } = await createProjectArchive(project);
+  const archiveBlob = new Blob([archiveData], { type: 'application/zip' });
+  const url = URL.createObjectURL(archiveBlob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = (data.meta?.title || 'roleplay') + '.json';
+  const baseName = sanitizeFilename(project.meta?.title, 'roleplay');
+  const downloadName = baseName && baseName.toLowerCase().endsWith('.zip')
+    ? baseName
+    : `${baseName}.zip`;
+  a.download = downloadName;
   document.body.appendChild(a);
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+
+  await reseedPersistence(project);
 }

--- a/public/scripts/storage.js
+++ b/public/scripts/storage.js
@@ -10,6 +10,7 @@ export async function importProject(store, file) {
   const cleanedScenes = base.scenes.map(scene => {
     const imported = createScene(scene);
     imported.image = null;
+    imported.backgroundAudio = null;
     imported.dialogue = imported.dialogue.map(line => ({ text: line.text || '', audio: null }));
     imported.choices = imported.choices.map(choice => createChoice({
       id: choice.id,
@@ -38,6 +39,7 @@ export async function exportProject(store) {
       id: scene.id,
       type: scene.type,
       image: scene.image ? { name: scene.image.name || '' } : null,
+      backgroundAudio: scene.backgroundAudio ? { name: scene.backgroundAudio.name || '' } : null,
       dialogue: scene.dialogue.map(line => ({
         text: line.text,
         audio: line.audio ? { name: line.audio.name || '' } : null,

--- a/public/scripts/utils/zip.js
+++ b/public/scripts/utils/zip.js
@@ -1,0 +1,21 @@
+import { zip as zipCallback, unzip as unzipCallback } from '../vendor/fflate.module.js';
+
+function toPromise(fn, ...args) {
+  return new Promise((resolve, reject) => {
+    fn(...args, (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+export function zip(sources, options) {
+  return toPromise(zipCallback, sources, options ?? {});
+}
+
+export function unzip(data, options) {
+  return toPromise(unzipCallback, data, options ?? {});
+}

--- a/public/scripts/vendor/fflate.module.js
+++ b/public/scripts/vendor/fflate.module.js
@@ -1,0 +1,2610 @@
+// DEFLATE is a complex format; to read this code, you should probably check the RFC first:
+// https://tools.ietf.org/html/rfc1951
+// You may also wish to take a look at the guide I made about this program:
+// https://gist.github.com/101arrowz/253f31eb5abc3d9275ab943003ffecad
+// Some of the following code is similar to that of UZIP.js:
+// https://github.com/photopea/UZIP.js
+// However, the vast majority of the codebase has diverged from UZIP.js to increase performance and reduce bundle size.
+// Sometimes 0 will appear where -1 would be more appropriate. This is because using a uint
+// is better for memory in most engines (I *think*).
+var ch2 = {};
+var wk = (function (c, id, msg, transfer, cb) {
+    var w = new Worker(ch2[id] || (ch2[id] = URL.createObjectURL(new Blob([
+        c + ';addEventListener("error",function(e){e=e.error;postMessage({$e$:[e.message,e.code,e.stack]})})'
+    ], { type: 'text/javascript' }))));
+    w.onmessage = function (e) {
+        var d = e.data, ed = d.$e$;
+        if (ed) {
+            var err = new Error(ed[0]);
+            err['code'] = ed[1];
+            err.stack = ed[2];
+            cb(err, null);
+        }
+        else
+            cb(null, d);
+    };
+    w.postMessage(msg, transfer);
+    return w;
+});
+
+// aliases for shorter compressed code (most minifers don't do this)
+var u8 = Uint8Array, u16 = Uint16Array, i32 = Int32Array;
+// fixed length extra bits
+var fleb = new u8([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, /* unused */ 0, 0, /* impossible */ 0]);
+// fixed distance extra bits
+var fdeb = new u8([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, /* unused */ 0, 0]);
+// code length index map
+var clim = new u8([16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]);
+// get base, reverse index map from extra bits
+var freb = function (eb, start) {
+    var b = new u16(31);
+    for (var i = 0; i < 31; ++i) {
+        b[i] = start += 1 << eb[i - 1];
+    }
+    // numbers here are at max 18 bits
+    var r = new i32(b[30]);
+    for (var i = 1; i < 30; ++i) {
+        for (var j = b[i]; j < b[i + 1]; ++j) {
+            r[j] = ((j - b[i]) << 5) | i;
+        }
+    }
+    return { b: b, r: r };
+};
+var _a = freb(fleb, 2), fl = _a.b, revfl = _a.r;
+// we can ignore the fact that the other numbers are wrong; they never happen anyway
+fl[28] = 258, revfl[258] = 28;
+var _b = freb(fdeb, 0), fd = _b.b, revfd = _b.r;
+// map of value to reverse (assuming 16 bits)
+var rev = new u16(32768);
+for (var i = 0; i < 32768; ++i) {
+    // reverse table algorithm from SO
+    var x = ((i & 0xAAAA) >> 1) | ((i & 0x5555) << 1);
+    x = ((x & 0xCCCC) >> 2) | ((x & 0x3333) << 2);
+    x = ((x & 0xF0F0) >> 4) | ((x & 0x0F0F) << 4);
+    rev[i] = (((x & 0xFF00) >> 8) | ((x & 0x00FF) << 8)) >> 1;
+}
+// create huffman tree from u8 "map": index -> code length for code index
+// mb (max bits) must be at most 15
+// TODO: optimize/split up?
+var hMap = (function (cd, mb, r) {
+    var s = cd.length;
+    // index
+    var i = 0;
+    // u16 "map": index -> # of codes with bit length = index
+    var l = new u16(mb);
+    // length of cd must be 288 (total # of codes)
+    for (; i < s; ++i) {
+        if (cd[i])
+            ++l[cd[i] - 1];
+    }
+    // u16 "map": index -> minimum code for bit length = index
+    var le = new u16(mb);
+    for (i = 1; i < mb; ++i) {
+        le[i] = (le[i - 1] + l[i - 1]) << 1;
+    }
+    var co;
+    if (r) {
+        // u16 "map": index -> number of actual bits, symbol for code
+        co = new u16(1 << mb);
+        // bits to remove for reverser
+        var rvb = 15 - mb;
+        for (i = 0; i < s; ++i) {
+            // ignore 0 lengths
+            if (cd[i]) {
+                // num encoding both symbol and bits read
+                var sv = (i << 4) | cd[i];
+                // free bits
+                var r_1 = mb - cd[i];
+                // start value
+                var v = le[cd[i] - 1]++ << r_1;
+                // m is end value
+                for (var m = v | ((1 << r_1) - 1); v <= m; ++v) {
+                    // every 16 bit value starting with the code yields the same result
+                    co[rev[v] >> rvb] = sv;
+                }
+            }
+        }
+    }
+    else {
+        co = new u16(s);
+        for (i = 0; i < s; ++i) {
+            if (cd[i]) {
+                co[i] = rev[le[cd[i] - 1]++] >> (15 - cd[i]);
+            }
+        }
+    }
+    return co;
+});
+// fixed length tree
+var flt = new u8(288);
+for (var i = 0; i < 144; ++i)
+    flt[i] = 8;
+for (var i = 144; i < 256; ++i)
+    flt[i] = 9;
+for (var i = 256; i < 280; ++i)
+    flt[i] = 7;
+for (var i = 280; i < 288; ++i)
+    flt[i] = 8;
+// fixed distance tree
+var fdt = new u8(32);
+for (var i = 0; i < 32; ++i)
+    fdt[i] = 5;
+// fixed length map
+var flm = /*#__PURE__*/ hMap(flt, 9, 0), flrm = /*#__PURE__*/ hMap(flt, 9, 1);
+// fixed distance map
+var fdm = /*#__PURE__*/ hMap(fdt, 5, 0), fdrm = /*#__PURE__*/ hMap(fdt, 5, 1);
+// find max of array
+var max = function (a) {
+    var m = a[0];
+    for (var i = 1; i < a.length; ++i) {
+        if (a[i] > m)
+            m = a[i];
+    }
+    return m;
+};
+// read d, starting at bit p and mask with m
+var bits = function (d, p, m) {
+    var o = (p / 8) | 0;
+    return ((d[o] | (d[o + 1] << 8)) >> (p & 7)) & m;
+};
+// read d, starting at bit p continuing for at least 16 bits
+var bits16 = function (d, p) {
+    var o = (p / 8) | 0;
+    return ((d[o] | (d[o + 1] << 8) | (d[o + 2] << 16)) >> (p & 7));
+};
+// get end of byte
+var shft = function (p) { return ((p + 7) / 8) | 0; };
+// typed array slice - allows garbage collector to free original reference,
+// while being more compatible than .slice
+var slc = function (v, s, e) {
+    if (s == null || s < 0)
+        s = 0;
+    if (e == null || e > v.length)
+        e = v.length;
+    // can't use .constructor in case user-supplied
+    var n = new u8(e - s);
+    n.set(v.subarray(s, e));
+    return n;
+};
+/**
+ * Codes for errors generated within this library
+ */
+export var FlateErrorCode = {
+    UnexpectedEOF: 0,
+    InvalidBlockType: 1,
+    InvalidLengthLiteral: 2,
+    InvalidDistance: 3,
+    StreamFinished: 4,
+    NoStreamHandler: 5,
+    InvalidHeader: 6,
+    NoCallback: 7,
+    InvalidUTF8: 8,
+    ExtraFieldTooLong: 9,
+    InvalidDate: 10,
+    FilenameTooLong: 11,
+    StreamFinishing: 12,
+    InvalidZipData: 13,
+    UnknownCompressionMethod: 14
+};
+// error codes
+var ec = [
+    'unexpected EOF',
+    'invalid block type',
+    'invalid length/literal',
+    'invalid distance',
+    'stream finished',
+    'no stream handler',
+    ,
+    'no callback',
+    'invalid UTF-8 data',
+    'extra field too long',
+    'date not in range 1980-2099',
+    'filename too long',
+    'stream finishing',
+    'invalid zip data'
+    // determined by unknown compression method
+];
+;
+var err = function (ind, msg, nt) {
+    var e = new Error(msg || ec[ind]);
+    e.code = ind;
+    if (Error.captureStackTrace)
+        Error.captureStackTrace(e, err);
+    if (!nt)
+        throw e;
+    return e;
+};
+// expands raw DEFLATE data
+var inflt = function (dat, st, buf, dict) {
+    // source length       dict length
+    var sl = dat.length, dl = dict ? dict.length : 0;
+    if (!sl || st.f && !st.l)
+        return buf || new u8(0);
+    // have to estimate size
+    var noBuf = !buf || st.i != 2;
+    // no state
+    var noSt = st.i;
+    // Assumes roughly 33% compression ratio average
+    if (!buf)
+        buf = new u8(sl * 3);
+    // ensure buffer can fit at least l elements
+    var cbuf = function (l) {
+        var bl = buf.length;
+        // need to increase size to fit
+        if (l > bl) {
+            // Double or set to necessary, whichever is greater
+            var nbuf = new u8(Math.max(bl * 2, l));
+            nbuf.set(buf);
+            buf = nbuf;
+        }
+    };
+    //  last chunk         bitpos           bytes
+    var final = st.f || 0, pos = st.p || 0, bt = st.b || 0, lm = st.l, dm = st.d, lbt = st.m, dbt = st.n;
+    // total bits
+    var tbts = sl * 8;
+    do {
+        if (!lm) {
+            // BFINAL - this is only 1 when last chunk is next
+            final = bits(dat, pos, 1);
+            // type: 0 = no compression, 1 = fixed huffman, 2 = dynamic huffman
+            var type = bits(dat, pos + 1, 3);
+            pos += 3;
+            if (!type) {
+                // go to end of byte boundary
+                var s = shft(pos) + 4, l = dat[s - 4] | (dat[s - 3] << 8), t = s + l;
+                if (t > sl) {
+                    if (noSt)
+                        err(0);
+                    break;
+                }
+                // ensure size
+                if (noBuf)
+                    cbuf(bt + l);
+                // Copy over uncompressed data
+                buf.set(dat.subarray(s, t), bt);
+                // Get new bitpos, update byte count
+                st.b = bt += l, st.p = pos = t * 8, st.f = final;
+                continue;
+            }
+            else if (type == 1)
+                lm = flrm, dm = fdrm, lbt = 9, dbt = 5;
+            else if (type == 2) {
+                //  literal                            lengths
+                var hLit = bits(dat, pos, 31) + 257, hcLen = bits(dat, pos + 10, 15) + 4;
+                var tl = hLit + bits(dat, pos + 5, 31) + 1;
+                pos += 14;
+                // length+distance tree
+                var ldt = new u8(tl);
+                // code length tree
+                var clt = new u8(19);
+                for (var i = 0; i < hcLen; ++i) {
+                    // use index map to get real code
+                    clt[clim[i]] = bits(dat, pos + i * 3, 7);
+                }
+                pos += hcLen * 3;
+                // code lengths bits
+                var clb = max(clt), clbmsk = (1 << clb) - 1;
+                // code lengths map
+                var clm = hMap(clt, clb, 1);
+                for (var i = 0; i < tl;) {
+                    var r = clm[bits(dat, pos, clbmsk)];
+                    // bits read
+                    pos += r & 15;
+                    // symbol
+                    var s = r >> 4;
+                    // code length to copy
+                    if (s < 16) {
+                        ldt[i++] = s;
+                    }
+                    else {
+                        //  copy   count
+                        var c = 0, n = 0;
+                        if (s == 16)
+                            n = 3 + bits(dat, pos, 3), pos += 2, c = ldt[i - 1];
+                        else if (s == 17)
+                            n = 3 + bits(dat, pos, 7), pos += 3;
+                        else if (s == 18)
+                            n = 11 + bits(dat, pos, 127), pos += 7;
+                        while (n--)
+                            ldt[i++] = c;
+                    }
+                }
+                //    length tree                 distance tree
+                var lt = ldt.subarray(0, hLit), dt = ldt.subarray(hLit);
+                // max length bits
+                lbt = max(lt);
+                // max dist bits
+                dbt = max(dt);
+                lm = hMap(lt, lbt, 1);
+                dm = hMap(dt, dbt, 1);
+            }
+            else
+                err(1);
+            if (pos > tbts) {
+                if (noSt)
+                    err(0);
+                break;
+            }
+        }
+        // Make sure the buffer can hold this + the largest possible addition
+        // Maximum chunk size (practically, theoretically infinite) is 2^17
+        if (noBuf)
+            cbuf(bt + 131072);
+        var lms = (1 << lbt) - 1, dms = (1 << dbt) - 1;
+        var lpos = pos;
+        for (;; lpos = pos) {
+            // bits read, code
+            var c = lm[bits16(dat, pos) & lms], sym = c >> 4;
+            pos += c & 15;
+            if (pos > tbts) {
+                if (noSt)
+                    err(0);
+                break;
+            }
+            if (!c)
+                err(2);
+            if (sym < 256)
+                buf[bt++] = sym;
+            else if (sym == 256) {
+                lpos = pos, lm = null;
+                break;
+            }
+            else {
+                var add = sym - 254;
+                // no extra bits needed if less
+                if (sym > 264) {
+                    // index
+                    var i = sym - 257, b = fleb[i];
+                    add = bits(dat, pos, (1 << b) - 1) + fl[i];
+                    pos += b;
+                }
+                // dist
+                var d = dm[bits16(dat, pos) & dms], dsym = d >> 4;
+                if (!d)
+                    err(3);
+                pos += d & 15;
+                var dt = fd[dsym];
+                if (dsym > 3) {
+                    var b = fdeb[dsym];
+                    dt += bits16(dat, pos) & (1 << b) - 1, pos += b;
+                }
+                if (pos > tbts) {
+                    if (noSt)
+                        err(0);
+                    break;
+                }
+                if (noBuf)
+                    cbuf(bt + 131072);
+                var end = bt + add;
+                if (bt < dt) {
+                    var shift = dl - dt, dend = Math.min(dt, end);
+                    if (shift + bt < 0)
+                        err(3);
+                    for (; bt < dend; ++bt)
+                        buf[bt] = dict[shift + bt];
+                }
+                for (; bt < end; bt += 4) {
+                    buf[bt] = buf[bt - dt];
+                    buf[bt + 1] = buf[bt + 1 - dt];
+                    buf[bt + 2] = buf[bt + 2 - dt];
+                    buf[bt + 3] = buf[bt + 3 - dt];
+                }
+                bt = end;
+            }
+        }
+        st.l = lm, st.p = lpos, st.b = bt, st.f = final;
+        if (lm)
+            final = 1, st.m = lbt, st.d = dm, st.n = dbt;
+    } while (!final);
+    return bt == buf.length ? buf : slc(buf, 0, bt);
+};
+// starting at p, write the minimum number of bits that can hold v to d
+var wbits = function (d, p, v) {
+    v <<= p & 7;
+    var o = (p / 8) | 0;
+    d[o] |= v;
+    d[o + 1] |= v >> 8;
+};
+// starting at p, write the minimum number of bits (>8) that can hold v to d
+var wbits16 = function (d, p, v) {
+    v <<= p & 7;
+    var o = (p / 8) | 0;
+    d[o] |= v;
+    d[o + 1] |= v >> 8;
+    d[o + 2] |= v >> 16;
+};
+// creates code lengths from a frequency table
+var hTree = function (d, mb) {
+    // Need extra info to make a tree
+    var t = [];
+    for (var i = 0; i < d.length; ++i) {
+        if (d[i])
+            t.push({ s: i, f: d[i] });
+    }
+    var s = t.length;
+    var t2 = t.slice();
+    if (!s)
+        return { t: et, l: 0 };
+    if (s == 1) {
+        var v = new u8(t[0].s + 1);
+        v[t[0].s] = 1;
+        return { t: v, l: 1 };
+    }
+    t.sort(function (a, b) { return a.f - b.f; });
+    // after i2 reaches last ind, will be stopped
+    // freq must be greater than largest possible number of symbols
+    t.push({ s: -1, f: 25001 });
+    var l = t[0], r = t[1], i0 = 0, i1 = 1, i2 = 2;
+    t[0] = { s: -1, f: l.f + r.f, l: l, r: r };
+    // efficient algorithm from UZIP.js
+    // i0 is lookbehind, i2 is lookahead - after processing two low-freq
+    // symbols that combined have high freq, will start processing i2 (high-freq,
+    // non-composite) symbols instead
+    // see https://reddit.com/r/photopea/comments/ikekht/uzipjs_questions/
+    while (i1 != s - 1) {
+        l = t[t[i0].f < t[i2].f ? i0++ : i2++];
+        r = t[i0 != i1 && t[i0].f < t[i2].f ? i0++ : i2++];
+        t[i1++] = { s: -1, f: l.f + r.f, l: l, r: r };
+    }
+    var maxSym = t2[0].s;
+    for (var i = 1; i < s; ++i) {
+        if (t2[i].s > maxSym)
+            maxSym = t2[i].s;
+    }
+    // code lengths
+    var tr = new u16(maxSym + 1);
+    // max bits in tree
+    var mbt = ln(t[i1 - 1], tr, 0);
+    if (mbt > mb) {
+        // more algorithms from UZIP.js
+        // TODO: find out how this code works (debt)
+        //  ind    debt
+        var i = 0, dt = 0;
+        //    left            cost
+        var lft = mbt - mb, cst = 1 << lft;
+        t2.sort(function (a, b) { return tr[b.s] - tr[a.s] || a.f - b.f; });
+        for (; i < s; ++i) {
+            var i2_1 = t2[i].s;
+            if (tr[i2_1] > mb) {
+                dt += cst - (1 << (mbt - tr[i2_1]));
+                tr[i2_1] = mb;
+            }
+            else
+                break;
+        }
+        dt >>= lft;
+        while (dt > 0) {
+            var i2_2 = t2[i].s;
+            if (tr[i2_2] < mb)
+                dt -= 1 << (mb - tr[i2_2]++ - 1);
+            else
+                ++i;
+        }
+        for (; i >= 0 && dt; --i) {
+            var i2_3 = t2[i].s;
+            if (tr[i2_3] == mb) {
+                --tr[i2_3];
+                ++dt;
+            }
+        }
+        mbt = mb;
+    }
+    return { t: new u8(tr), l: mbt };
+};
+// get the max length and assign length codes
+var ln = function (n, l, d) {
+    return n.s == -1
+        ? Math.max(ln(n.l, l, d + 1), ln(n.r, l, d + 1))
+        : (l[n.s] = d);
+};
+// length codes generation
+var lc = function (c) {
+    var s = c.length;
+    // Note that the semicolon was intentional
+    while (s && !c[--s])
+        ;
+    var cl = new u16(++s);
+    //  ind      num         streak
+    var cli = 0, cln = c[0], cls = 1;
+    var w = function (v) { cl[cli++] = v; };
+    for (var i = 1; i <= s; ++i) {
+        if (c[i] == cln && i != s)
+            ++cls;
+        else {
+            if (!cln && cls > 2) {
+                for (; cls > 138; cls -= 138)
+                    w(32754);
+                if (cls > 2) {
+                    w(cls > 10 ? ((cls - 11) << 5) | 28690 : ((cls - 3) << 5) | 12305);
+                    cls = 0;
+                }
+            }
+            else if (cls > 3) {
+                w(cln), --cls;
+                for (; cls > 6; cls -= 6)
+                    w(8304);
+                if (cls > 2)
+                    w(((cls - 3) << 5) | 8208), cls = 0;
+            }
+            while (cls--)
+                w(cln);
+            cls = 1;
+            cln = c[i];
+        }
+    }
+    return { c: cl.subarray(0, cli), n: s };
+};
+// calculate the length of output from tree, code lengths
+var clen = function (cf, cl) {
+    var l = 0;
+    for (var i = 0; i < cl.length; ++i)
+        l += cf[i] * cl[i];
+    return l;
+};
+// writes a fixed block
+// returns the new bit pos
+var wfblk = function (out, pos, dat) {
+    // no need to write 00 as type: TypedArray defaults to 0
+    var s = dat.length;
+    var o = shft(pos + 2);
+    out[o] = s & 255;
+    out[o + 1] = s >> 8;
+    out[o + 2] = out[o] ^ 255;
+    out[o + 3] = out[o + 1] ^ 255;
+    for (var i = 0; i < s; ++i)
+        out[o + i + 4] = dat[i];
+    return (o + 4 + s) * 8;
+};
+// writes a block
+var wblk = function (dat, out, final, syms, lf, df, eb, li, bs, bl, p) {
+    wbits(out, p++, final);
+    ++lf[256];
+    var _a = hTree(lf, 15), dlt = _a.t, mlb = _a.l;
+    var _b = hTree(df, 15), ddt = _b.t, mdb = _b.l;
+    var _c = lc(dlt), lclt = _c.c, nlc = _c.n;
+    var _d = lc(ddt), lcdt = _d.c, ndc = _d.n;
+    var lcfreq = new u16(19);
+    for (var i = 0; i < lclt.length; ++i)
+        ++lcfreq[lclt[i] & 31];
+    for (var i = 0; i < lcdt.length; ++i)
+        ++lcfreq[lcdt[i] & 31];
+    var _e = hTree(lcfreq, 7), lct = _e.t, mlcb = _e.l;
+    var nlcc = 19;
+    for (; nlcc > 4 && !lct[clim[nlcc - 1]]; --nlcc)
+        ;
+    var flen = (bl + 5) << 3;
+    var ftlen = clen(lf, flt) + clen(df, fdt) + eb;
+    var dtlen = clen(lf, dlt) + clen(df, ddt) + eb + 14 + 3 * nlcc + clen(lcfreq, lct) + 2 * lcfreq[16] + 3 * lcfreq[17] + 7 * lcfreq[18];
+    if (bs >= 0 && flen <= ftlen && flen <= dtlen)
+        return wfblk(out, p, dat.subarray(bs, bs + bl));
+    var lm, ll, dm, dl;
+    wbits(out, p, 1 + (dtlen < ftlen)), p += 2;
+    if (dtlen < ftlen) {
+        lm = hMap(dlt, mlb, 0), ll = dlt, dm = hMap(ddt, mdb, 0), dl = ddt;
+        var llm = hMap(lct, mlcb, 0);
+        wbits(out, p, nlc - 257);
+        wbits(out, p + 5, ndc - 1);
+        wbits(out, p + 10, nlcc - 4);
+        p += 14;
+        for (var i = 0; i < nlcc; ++i)
+            wbits(out, p + 3 * i, lct[clim[i]]);
+        p += 3 * nlcc;
+        var lcts = [lclt, lcdt];
+        for (var it = 0; it < 2; ++it) {
+            var clct = lcts[it];
+            for (var i = 0; i < clct.length; ++i) {
+                var len = clct[i] & 31;
+                wbits(out, p, llm[len]), p += lct[len];
+                if (len > 15)
+                    wbits(out, p, (clct[i] >> 5) & 127), p += clct[i] >> 12;
+            }
+        }
+    }
+    else {
+        lm = flm, ll = flt, dm = fdm, dl = fdt;
+    }
+    for (var i = 0; i < li; ++i) {
+        var sym = syms[i];
+        if (sym > 255) {
+            var len = (sym >> 18) & 31;
+            wbits16(out, p, lm[len + 257]), p += ll[len + 257];
+            if (len > 7)
+                wbits(out, p, (sym >> 23) & 31), p += fleb[len];
+            var dst = sym & 31;
+            wbits16(out, p, dm[dst]), p += dl[dst];
+            if (dst > 3)
+                wbits16(out, p, (sym >> 5) & 8191), p += fdeb[dst];
+        }
+        else {
+            wbits16(out, p, lm[sym]), p += ll[sym];
+        }
+    }
+    wbits16(out, p, lm[256]);
+    return p + ll[256];
+};
+// deflate options (nice << 13) | chain
+var deo = /*#__PURE__*/ new i32([65540, 131080, 131088, 131104, 262176, 1048704, 1048832, 2114560, 2117632]);
+// empty
+var et = /*#__PURE__*/ new u8(0);
+// compresses data into a raw DEFLATE buffer
+var dflt = function (dat, lvl, plvl, pre, post, st) {
+    var s = st.z || dat.length;
+    var o = new u8(pre + s + 5 * (1 + Math.ceil(s / 7000)) + post);
+    // writing to this writes to the output buffer
+    var w = o.subarray(pre, o.length - post);
+    var lst = st.l;
+    var pos = (st.r || 0) & 7;
+    if (lvl) {
+        if (pos)
+            w[0] = st.r >> 3;
+        var opt = deo[lvl - 1];
+        var n = opt >> 13, c = opt & 8191;
+        var msk_1 = (1 << plvl) - 1;
+        //    prev 2-byte val map    curr 2-byte val map
+        var prev = st.p || new u16(32768), head = st.h || new u16(msk_1 + 1);
+        var bs1_1 = Math.ceil(plvl / 3), bs2_1 = 2 * bs1_1;
+        var hsh = function (i) { return (dat[i] ^ (dat[i + 1] << bs1_1) ^ (dat[i + 2] << bs2_1)) & msk_1; };
+        // 24576 is an arbitrary number of maximum symbols per block
+        // 424 buffer for last block
+        var syms = new i32(25000);
+        // length/literal freq   distance freq
+        var lf = new u16(288), df = new u16(32);
+        //  l/lcnt  exbits  index          l/lind  waitdx          blkpos
+        var lc_1 = 0, eb = 0, i = st.i || 0, li = 0, wi = st.w || 0, bs = 0;
+        for (; i + 2 < s; ++i) {
+            // hash value
+            var hv = hsh(i);
+            // index mod 32768    previous index mod
+            var imod = i & 32767, pimod = head[hv];
+            prev[imod] = pimod;
+            head[hv] = imod;
+            // We always should modify head and prev, but only add symbols if
+            // this data is not yet processed ("wait" for wait index)
+            if (wi <= i) {
+                // bytes remaining
+                var rem = s - i;
+                if ((lc_1 > 7000 || li > 24576) && (rem > 423 || !lst)) {
+                    pos = wblk(dat, w, 0, syms, lf, df, eb, li, bs, i - bs, pos);
+                    li = lc_1 = eb = 0, bs = i;
+                    for (var j = 0; j < 286; ++j)
+                        lf[j] = 0;
+                    for (var j = 0; j < 30; ++j)
+                        df[j] = 0;
+                }
+                //  len    dist   chain
+                var l = 2, d = 0, ch_1 = c, dif = imod - pimod & 32767;
+                if (rem > 2 && hv == hsh(i - dif)) {
+                    var maxn = Math.min(n, rem) - 1;
+                    var maxd = Math.min(32767, i);
+                    // max possible length
+                    // not capped at dif because decompressors implement "rolling" index population
+                    var ml = Math.min(258, rem);
+                    while (dif <= maxd && --ch_1 && imod != pimod) {
+                        if (dat[i + l] == dat[i + l - dif]) {
+                            var nl = 0;
+                            for (; nl < ml && dat[i + nl] == dat[i + nl - dif]; ++nl)
+                                ;
+                            if (nl > l) {
+                                l = nl, d = dif;
+                                // break out early when we reach "nice" (we are satisfied enough)
+                                if (nl > maxn)
+                                    break;
+                                // now, find the rarest 2-byte sequence within this
+                                // length of literals and search for that instead.
+                                // Much faster than just using the start
+                                var mmd = Math.min(dif, nl - 2);
+                                var md = 0;
+                                for (var j = 0; j < mmd; ++j) {
+                                    var ti = i - dif + j & 32767;
+                                    var pti = prev[ti];
+                                    var cd = ti - pti & 32767;
+                                    if (cd > md)
+                                        md = cd, pimod = ti;
+                                }
+                            }
+                        }
+                        // check the previous match
+                        imod = pimod, pimod = prev[imod];
+                        dif += imod - pimod & 32767;
+                    }
+                }
+                // d will be nonzero only when a match was found
+                if (d) {
+                    // store both dist and len data in one int32
+                    // Make sure this is recognized as a len/dist with 28th bit (2^28)
+                    syms[li++] = 268435456 | (revfl[l] << 18) | revfd[d];
+                    var lin = revfl[l] & 31, din = revfd[d] & 31;
+                    eb += fleb[lin] + fdeb[din];
+                    ++lf[257 + lin];
+                    ++df[din];
+                    wi = i + l;
+                    ++lc_1;
+                }
+                else {
+                    syms[li++] = dat[i];
+                    ++lf[dat[i]];
+                }
+            }
+        }
+        for (i = Math.max(i, wi); i < s; ++i) {
+            syms[li++] = dat[i];
+            ++lf[dat[i]];
+        }
+        pos = wblk(dat, w, lst, syms, lf, df, eb, li, bs, i - bs, pos);
+        if (!lst) {
+            st.r = (pos & 7) | w[(pos / 8) | 0] << 3;
+            // shft(pos) now 1 less if pos & 7 != 0
+            pos -= 7;
+            st.h = head, st.p = prev, st.i = i, st.w = wi;
+        }
+    }
+    else {
+        for (var i = st.w || 0; i < s + lst; i += 65535) {
+            // end
+            var e = i + 65535;
+            if (e >= s) {
+                // write final block
+                w[(pos / 8) | 0] = lst;
+                e = s;
+            }
+            pos = wfblk(w, pos + 1, dat.subarray(i, e));
+        }
+        st.i = s;
+    }
+    return slc(o, 0, pre + shft(pos) + post);
+};
+// CRC32 table
+var crct = /*#__PURE__*/ (function () {
+    var t = new Int32Array(256);
+    for (var i = 0; i < 256; ++i) {
+        var c = i, k = 9;
+        while (--k)
+            c = ((c & 1) && -306674912) ^ (c >>> 1);
+        t[i] = c;
+    }
+    return t;
+})();
+// CRC32
+var crc = function () {
+    var c = -1;
+    return {
+        p: function (d) {
+            // closures have awful performance
+            var cr = c;
+            for (var i = 0; i < d.length; ++i)
+                cr = crct[(cr & 255) ^ d[i]] ^ (cr >>> 8);
+            c = cr;
+        },
+        d: function () { return ~c; }
+    };
+};
+// Adler32
+var adler = function () {
+    var a = 1, b = 0;
+    return {
+        p: function (d) {
+            // closures have awful performance
+            var n = a, m = b;
+            var l = d.length | 0;
+            for (var i = 0; i != l;) {
+                var e = Math.min(i + 2655, l);
+                for (; i < e; ++i)
+                    m += n += d[i];
+                n = (n & 65535) + 15 * (n >> 16), m = (m & 65535) + 15 * (m >> 16);
+            }
+            a = n, b = m;
+        },
+        d: function () {
+            a %= 65521, b %= 65521;
+            return (a & 255) << 24 | (a & 0xFF00) << 8 | (b & 255) << 8 | (b >> 8);
+        }
+    };
+};
+;
+// deflate with opts
+var dopt = function (dat, opt, pre, post, st) {
+    if (!st) {
+        st = { l: 1 };
+        if (opt.dictionary) {
+            var dict = opt.dictionary.subarray(-32768);
+            var newDat = new u8(dict.length + dat.length);
+            newDat.set(dict);
+            newDat.set(dat, dict.length);
+            dat = newDat;
+            st.w = dict.length;
+        }
+    }
+    return dflt(dat, opt.level == null ? 6 : opt.level, opt.mem == null ? Math.ceil(Math.max(8, Math.min(13, Math.log(dat.length))) * 1.5) : (12 + opt.mem), pre, post, st);
+};
+// Walmart object spread
+var mrg = function (a, b) {
+    var o = {};
+    for (var k in a)
+        o[k] = a[k];
+    for (var k in b)
+        o[k] = b[k];
+    return o;
+};
+// worker clone
+// This is possibly the craziest part of the entire codebase, despite how simple it may seem.
+// The only parameter to this function is a closure that returns an array of variables outside of the function scope.
+// We're going to try to figure out the variable names used in the closure as strings because that is crucial for workerization.
+// We will return an object mapping of true variable name to value (basically, the current scope as a JS object).
+// The reason we can't just use the original variable names is minifiers mangling the toplevel scope.
+// This took me three weeks to figure out how to do.
+var wcln = function (fn, fnStr, td) {
+    var dt = fn();
+    var st = fn.toString();
+    var ks = st.slice(st.indexOf('[') + 1, st.lastIndexOf(']')).replace(/\s+/g, '').split(',');
+    for (var i = 0; i < dt.length; ++i) {
+        var v = dt[i], k = ks[i];
+        if (typeof v == 'function') {
+            fnStr += ';' + k + '=';
+            var st_1 = v.toString();
+            if (v.prototype) {
+                // for global objects
+                if (st_1.indexOf('[native code]') != -1) {
+                    var spInd = st_1.indexOf(' ', 8) + 1;
+                    fnStr += st_1.slice(spInd, st_1.indexOf('(', spInd));
+                }
+                else {
+                    fnStr += st_1;
+                    for (var t in v.prototype)
+                        fnStr += ';' + k + '.prototype.' + t + '=' + v.prototype[t].toString();
+                }
+            }
+            else
+                fnStr += st_1;
+        }
+        else
+            td[k] = v;
+    }
+    return fnStr;
+};
+var ch = [];
+// clone bufs
+var cbfs = function (v) {
+    var tl = [];
+    for (var k in v) {
+        if (v[k].buffer) {
+            tl.push((v[k] = new v[k].constructor(v[k])).buffer);
+        }
+    }
+    return tl;
+};
+// use a worker to execute code
+var wrkr = function (fns, init, id, cb) {
+    if (!ch[id]) {
+        var fnStr = '', td_1 = {}, m = fns.length - 1;
+        for (var i = 0; i < m; ++i)
+            fnStr = wcln(fns[i], fnStr, td_1);
+        ch[id] = { c: wcln(fns[m], fnStr, td_1), e: td_1 };
+    }
+    var td = mrg({}, ch[id].e);
+    return wk(ch[id].c + ';onmessage=function(e){for(var k in e.data)self[k]=e.data[k];onmessage=' + init.toString() + '}', id, td, cbfs(td), cb);
+};
+// base async inflate fn
+var bInflt = function () { return [u8, u16, i32, fleb, fdeb, clim, fl, fd, flrm, fdrm, rev, ec, hMap, max, bits, bits16, shft, slc, err, inflt, inflateSync, pbf, gopt]; };
+var bDflt = function () { return [u8, u16, i32, fleb, fdeb, clim, revfl, revfd, flm, flt, fdm, fdt, rev, deo, et, hMap, wbits, wbits16, hTree, ln, lc, clen, wfblk, wblk, shft, slc, dflt, dopt, deflateSync, pbf]; };
+// gzip extra
+var gze = function () { return [gzh, gzhl, wbytes, crc, crct]; };
+// gunzip extra
+var guze = function () { return [gzs, gzl]; };
+// zlib extra
+var zle = function () { return [zlh, wbytes, adler]; };
+// unzlib extra
+var zule = function () { return [zls]; };
+// post buf
+var pbf = function (msg) { return postMessage(msg, [msg.buffer]); };
+// get opts
+var gopt = function (o) { return o && {
+    out: o.size && new u8(o.size),
+    dictionary: o.dictionary
+}; };
+// async helper
+var cbify = function (dat, opts, fns, init, id, cb) {
+    var w = wrkr(fns, init, id, function (err, dat) {
+        w.terminate();
+        cb(err, dat);
+    });
+    w.postMessage([dat, opts], opts.consume ? [dat.buffer] : []);
+    return function () { w.terminate(); };
+};
+// auto stream
+var astrm = function (strm) {
+    strm.ondata = function (dat, final) { return postMessage([dat, final], [dat.buffer]); };
+    return function (ev) { return strm.push(ev.data[0], ev.data[1]); };
+};
+// async stream attach
+var astrmify = function (fns, strm, opts, init, id, ext) {
+    var t;
+    var w = wrkr(fns, init, id, function (err, dat) {
+        if (err)
+            w.terminate(), strm.ondata.call(strm, err);
+        else if (!Array.isArray(dat))
+            ext(dat);
+        else {
+            if (dat[1])
+                w.terminate();
+            strm.ondata.call(strm, err, dat[0], dat[1]);
+        }
+    });
+    w.postMessage(opts);
+    strm.push = function (d, f) {
+        if (!strm.ondata)
+            err(5);
+        if (t)
+            strm.ondata(err(4, 0, 1), null, !!f);
+        w.postMessage([d, t = f], [d.buffer]);
+    };
+    strm.terminate = function () { w.terminate(); };
+};
+// read 2 bytes
+var b2 = function (d, b) { return d[b] | (d[b + 1] << 8); };
+// read 4 bytes
+var b4 = function (d, b) { return (d[b] | (d[b + 1] << 8) | (d[b + 2] << 16) | (d[b + 3] << 24)) >>> 0; };
+var b8 = function (d, b) { return b4(d, b) + (b4(d, b + 4) * 4294967296); };
+// write bytes
+var wbytes = function (d, b, v) {
+    for (; v; ++b)
+        d[b] = v, v >>>= 8;
+};
+// gzip header
+var gzh = function (c, o) {
+    var fn = o.filename;
+    c[0] = 31, c[1] = 139, c[2] = 8, c[8] = o.level < 2 ? 4 : o.level == 9 ? 2 : 0, c[9] = 3; // assume Unix
+    if (o.mtime != 0)
+        wbytes(c, 4, Math.floor(new Date(o.mtime || Date.now()) / 1000));
+    if (fn) {
+        c[3] = 8;
+        for (var i = 0; i <= fn.length; ++i)
+            c[i + 10] = fn.charCodeAt(i);
+    }
+};
+// gzip footer: -8 to -4 = CRC, -4 to -0 is length
+// gzip start
+var gzs = function (d) {
+    if (d[0] != 31 || d[1] != 139 || d[2] != 8)
+        err(6, 'invalid gzip data');
+    var flg = d[3];
+    var st = 10;
+    if (flg & 4)
+        st += (d[10] | d[11] << 8) + 2;
+    for (var zs = (flg >> 3 & 1) + (flg >> 4 & 1); zs > 0; zs -= !d[st++])
+        ;
+    return st + (flg & 2);
+};
+// gzip length
+var gzl = function (d) {
+    var l = d.length;
+    return (d[l - 4] | d[l - 3] << 8 | d[l - 2] << 16 | d[l - 1] << 24) >>> 0;
+};
+// gzip header length
+var gzhl = function (o) { return 10 + (o.filename ? o.filename.length + 1 : 0); };
+// zlib header
+var zlh = function (c, o) {
+    var lv = o.level, fl = lv == 0 ? 0 : lv < 6 ? 1 : lv == 9 ? 3 : 2;
+    c[0] = 120, c[1] = (fl << 6) | (o.dictionary && 32);
+    c[1] |= 31 - ((c[0] << 8) | c[1]) % 31;
+    if (o.dictionary) {
+        var h = adler();
+        h.p(o.dictionary);
+        wbytes(c, 2, h.d());
+    }
+};
+// zlib start
+var zls = function (d, dict) {
+    if ((d[0] & 15) != 8 || (d[0] >> 4) > 7 || ((d[0] << 8 | d[1]) % 31))
+        err(6, 'invalid zlib data');
+    if ((d[1] >> 5 & 1) == +!dict)
+        err(6, 'invalid zlib data: ' + (d[1] & 32 ? 'need' : 'unexpected') + ' dictionary');
+    return (d[1] >> 3 & 4) + 2;
+};
+function StrmOpt(opts, cb) {
+    if (typeof opts == 'function')
+        cb = opts, opts = {};
+    this.ondata = cb;
+    return opts;
+}
+/**
+ * Streaming DEFLATE compression
+ */
+var Deflate = /*#__PURE__*/ (function () {
+    function Deflate(opts, cb) {
+        if (typeof opts == 'function')
+            cb = opts, opts = {};
+        this.ondata = cb;
+        this.o = opts || {};
+        this.s = { l: 0, i: 32768, w: 32768, z: 32768 };
+        // Buffer length must always be 0 mod 32768 for index calculations to be correct when modifying head and prev
+        // 98304 = 32768 (lookback) + 65536 (common chunk size)
+        this.b = new u8(98304);
+        if (this.o.dictionary) {
+            var dict = this.o.dictionary.subarray(-32768);
+            this.b.set(dict, 32768 - dict.length);
+            this.s.i = 32768 - dict.length;
+        }
+    }
+    Deflate.prototype.p = function (c, f) {
+        this.ondata(dopt(c, this.o, 0, 0, this.s), f);
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Deflate.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (this.s.l)
+            err(4);
+        var endLen = chunk.length + this.s.z;
+        if (endLen > this.b.length) {
+            if (endLen > 2 * this.b.length - 32768) {
+                var newBuf = new u8(endLen & -32768);
+                newBuf.set(this.b.subarray(0, this.s.z));
+                this.b = newBuf;
+            }
+            var split = this.b.length - this.s.z;
+            if (split) {
+                this.b.set(chunk.subarray(0, split), this.s.z);
+                this.s.z = this.b.length;
+                this.p(this.b, false);
+            }
+            this.b.set(this.b.subarray(-32768));
+            this.b.set(chunk.subarray(split), 32768);
+            this.s.z = chunk.length - split + 32768;
+            this.s.i = 32766, this.s.w = 32768;
+        }
+        else {
+            this.b.set(chunk, this.s.z);
+            this.s.z += chunk.length;
+        }
+        this.s.l = final & 1;
+        if (this.s.z > this.s.w + 8191 || final) {
+            this.p(this.b, final || false);
+            this.s.w = this.s.i, this.s.i -= 2;
+        }
+    };
+    return Deflate;
+}());
+export { Deflate };
+/**
+ * Asynchronous streaming DEFLATE compression
+ */
+var AsyncDeflate = /*#__PURE__*/ (function () {
+    function AsyncDeflate(opts, cb) {
+        astrmify([
+            bDflt,
+            function () { return [astrm, Deflate]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Deflate(ev.data);
+            onmessage = astrm(strm);
+        }, 6);
+    }
+    return AsyncDeflate;
+}());
+export { AsyncDeflate };
+export function deflate(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+    ], function (ev) { return pbf(deflateSync(ev.data[0], ev.data[1])); }, 0, cb);
+}
+/**
+ * Compresses data with DEFLATE without any wrapper
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The deflated version of the data
+ */
+export function deflateSync(data, opts) {
+    return dopt(data, opts || {}, 0, 0);
+}
+/**
+ * Streaming DEFLATE decompression
+ */
+var Inflate = /*#__PURE__*/ (function () {
+    function Inflate(opts, cb) {
+        // no StrmOpt here to avoid adding to workerizer
+        if (typeof opts == 'function')
+            cb = opts, opts = {};
+        this.ondata = cb;
+        var dict = opts && opts.dictionary && opts.dictionary.subarray(-32768);
+        this.s = { i: 0, b: dict ? dict.length : 0 };
+        this.o = new u8(32768);
+        this.p = new u8(0);
+        if (dict)
+            this.o.set(dict);
+    }
+    Inflate.prototype.e = function (c) {
+        if (!this.ondata)
+            err(5);
+        if (this.d)
+            err(4);
+        if (!this.p.length)
+            this.p = c;
+        else if (c.length) {
+            var n = new u8(this.p.length + c.length);
+            n.set(this.p), n.set(c, this.p.length), this.p = n;
+        }
+    };
+    Inflate.prototype.c = function (final) {
+        this.s.i = +(this.d = final || false);
+        var bts = this.s.b;
+        var dt = inflt(this.p, this.s, this.o);
+        this.ondata(slc(dt, bts, this.s.b), this.d);
+        this.o = slc(dt, this.s.b - 32768), this.s.b = this.o.length;
+        this.p = slc(this.p, (this.s.p / 8) | 0), this.s.p &= 7;
+    };
+    /**
+     * Pushes a chunk to be inflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the final chunk
+     */
+    Inflate.prototype.push = function (chunk, final) {
+        this.e(chunk), this.c(final);
+    };
+    return Inflate;
+}());
+export { Inflate };
+/**
+ * Asynchronous streaming DEFLATE decompression
+ */
+var AsyncInflate = /*#__PURE__*/ (function () {
+    function AsyncInflate(opts, cb) {
+        astrmify([
+            bInflt,
+            function () { return [astrm, Inflate]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Inflate(ev.data);
+            onmessage = astrm(strm);
+        }, 7);
+    }
+    return AsyncInflate;
+}());
+export { AsyncInflate };
+export function inflate(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt
+    ], function (ev) { return pbf(inflateSync(ev.data[0], gopt(ev.data[1]))); }, 1, cb);
+}
+/**
+ * Expands DEFLATE data with no wrapper
+ * @param data The data to decompress
+ * @param opts The decompression options
+ * @returns The decompressed version of the data
+ */
+export function inflateSync(data, opts) {
+    return inflt(data, { i: 2 }, opts && opts.out, opts && opts.dictionary);
+}
+// before you yell at me for not just using extends, my reason is that TS inheritance is hard to workerize.
+/**
+ * Streaming GZIP compression
+ */
+var Gzip = /*#__PURE__*/ (function () {
+    function Gzip(opts, cb) {
+        this.c = crc();
+        this.l = 0;
+        this.v = 1;
+        Deflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be GZIPped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Gzip.prototype.push = function (chunk, final) {
+        this.c.p(chunk);
+        this.l += chunk.length;
+        Deflate.prototype.push.call(this, chunk, final);
+    };
+    Gzip.prototype.p = function (c, f) {
+        var raw = dopt(c, this.o, this.v && gzhl(this.o), f && 8, this.s);
+        if (this.v)
+            gzh(raw, this.o), this.v = 0;
+        if (f)
+            wbytes(raw, raw.length - 8, this.c.d()), wbytes(raw, raw.length - 4, this.l);
+        this.ondata(raw, f);
+    };
+    return Gzip;
+}());
+export { Gzip };
+/**
+ * Asynchronous streaming GZIP compression
+ */
+var AsyncGzip = /*#__PURE__*/ (function () {
+    function AsyncGzip(opts, cb) {
+        astrmify([
+            bDflt,
+            gze,
+            function () { return [astrm, Deflate, Gzip]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Gzip(ev.data);
+            onmessage = astrm(strm);
+        }, 8);
+    }
+    return AsyncGzip;
+}());
+export { AsyncGzip };
+export function gzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+        gze,
+        function () { return [gzipSync]; }
+    ], function (ev) { return pbf(gzipSync(ev.data[0], ev.data[1])); }, 2, cb);
+}
+/**
+ * Compresses data with GZIP
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The gzipped version of the data
+ */
+export function gzipSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var c = crc(), l = data.length;
+    c.p(data);
+    var d = dopt(data, opts, gzhl(opts), 8), s = d.length;
+    return gzh(d, opts), wbytes(d, s - 8, c.d()), wbytes(d, s - 4, l), d;
+}
+/**
+ * Streaming single or multi-member GZIP decompression
+ */
+var Gunzip = /*#__PURE__*/ (function () {
+    function Gunzip(opts, cb) {
+        this.v = 1;
+        this.r = 0;
+        Inflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be GUNZIPped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Gunzip.prototype.push = function (chunk, final) {
+        Inflate.prototype.e.call(this, chunk);
+        this.r += chunk.length;
+        if (this.v) {
+            var p = this.p.subarray(this.v - 1);
+            var s = p.length > 3 ? gzs(p) : 4;
+            if (s > p.length) {
+                if (!final)
+                    return;
+            }
+            else if (this.v > 1 && this.onmember) {
+                this.onmember(this.r - p.length);
+            }
+            this.p = p.subarray(s), this.v = 0;
+        }
+        // necessary to prevent TS from using the closure value
+        // This allows for workerization to function correctly
+        Inflate.prototype.c.call(this, final);
+        // process concatenated GZIP
+        if (this.s.f && !this.s.l) {
+            this.v = shft(this.s.p) + 9;
+            this.s = { i: 0 };
+            this.o = new u8(0);
+            if (this.p.length)
+                this.push(new u8(0), final);
+        }
+    };
+    return Gunzip;
+}());
+export { Gunzip };
+/**
+ * Asynchronous streaming single or multi-member GZIP decompression
+ */
+var AsyncGunzip = /*#__PURE__*/ (function () {
+    function AsyncGunzip(opts, cb) {
+        var _this_1 = this;
+        astrmify([
+            bInflt,
+            guze,
+            function () { return [astrm, Inflate, Gunzip]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Gunzip(ev.data);
+            strm.onmember = function (offset) { return postMessage(offset); };
+            onmessage = astrm(strm);
+        }, 9, function (offset) { return _this_1.onmember && _this_1.onmember(offset); });
+    }
+    return AsyncGunzip;
+}());
+export { AsyncGunzip };
+export function gunzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt,
+        guze,
+        function () { return [gunzipSync]; }
+    ], function (ev) { return pbf(gunzipSync(ev.data[0], ev.data[1])); }, 3, cb);
+}
+/**
+ * Expands GZIP data
+ * @param data The data to decompress
+ * @param opts The decompression options
+ * @returns The decompressed version of the data
+ */
+export function gunzipSync(data, opts) {
+    var st = gzs(data);
+    if (st + 8 > data.length)
+        err(6, 'invalid gzip data');
+    return inflt(data.subarray(st, -8), { i: 2 }, opts && opts.out || new u8(gzl(data)), opts && opts.dictionary);
+}
+/**
+ * Streaming Zlib compression
+ */
+var Zlib = /*#__PURE__*/ (function () {
+    function Zlib(opts, cb) {
+        this.c = adler();
+        this.v = 1;
+        Deflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be zlibbed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Zlib.prototype.push = function (chunk, final) {
+        this.c.p(chunk);
+        Deflate.prototype.push.call(this, chunk, final);
+    };
+    Zlib.prototype.p = function (c, f) {
+        var raw = dopt(c, this.o, this.v && (this.o.dictionary ? 6 : 2), f && 4, this.s);
+        if (this.v)
+            zlh(raw, this.o), this.v = 0;
+        if (f)
+            wbytes(raw, raw.length - 4, this.c.d());
+        this.ondata(raw, f);
+    };
+    return Zlib;
+}());
+export { Zlib };
+/**
+ * Asynchronous streaming Zlib compression
+ */
+var AsyncZlib = /*#__PURE__*/ (function () {
+    function AsyncZlib(opts, cb) {
+        astrmify([
+            bDflt,
+            zle,
+            function () { return [astrm, Deflate, Zlib]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Zlib(ev.data);
+            onmessage = astrm(strm);
+        }, 10);
+    }
+    return AsyncZlib;
+}());
+export { AsyncZlib };
+export function zlib(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+        zle,
+        function () { return [zlibSync]; }
+    ], function (ev) { return pbf(zlibSync(ev.data[0], ev.data[1])); }, 4, cb);
+}
+/**
+ * Compress data with Zlib
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The zlib-compressed version of the data
+ */
+export function zlibSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var a = adler();
+    a.p(data);
+    var d = dopt(data, opts, opts.dictionary ? 6 : 2, 4);
+    return zlh(d, opts), wbytes(d, d.length - 4, a.d()), d;
+}
+/**
+ * Streaming Zlib decompression
+ */
+var Unzlib = /*#__PURE__*/ (function () {
+    function Unzlib(opts, cb) {
+        Inflate.call(this, opts, cb);
+        this.v = opts && opts.dictionary ? 2 : 1;
+    }
+    /**
+     * Pushes a chunk to be unzlibbed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Unzlib.prototype.push = function (chunk, final) {
+        Inflate.prototype.e.call(this, chunk);
+        if (this.v) {
+            if (this.p.length < 6 && !final)
+                return;
+            this.p = this.p.subarray(zls(this.p, this.v - 1)), this.v = 0;
+        }
+        if (final) {
+            if (this.p.length < 4)
+                err(6, 'invalid zlib data');
+            this.p = this.p.subarray(0, -4);
+        }
+        // necessary to prevent TS from using the closure value
+        // This allows for workerization to function correctly
+        Inflate.prototype.c.call(this, final);
+    };
+    return Unzlib;
+}());
+export { Unzlib };
+/**
+ * Asynchronous streaming Zlib decompression
+ */
+var AsyncUnzlib = /*#__PURE__*/ (function () {
+    function AsyncUnzlib(opts, cb) {
+        astrmify([
+            bInflt,
+            zule,
+            function () { return [astrm, Inflate, Unzlib]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Unzlib(ev.data);
+            onmessage = astrm(strm);
+        }, 11);
+    }
+    return AsyncUnzlib;
+}());
+export { AsyncUnzlib };
+export function unzlib(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt,
+        zule,
+        function () { return [unzlibSync]; }
+    ], function (ev) { return pbf(unzlibSync(ev.data[0], gopt(ev.data[1]))); }, 5, cb);
+}
+/**
+ * Expands Zlib data
+ * @param data The data to decompress
+ * @param opts The decompression options
+ * @returns The decompressed version of the data
+ */
+export function unzlibSync(data, opts) {
+    return inflt(data.subarray(zls(data, opts && opts.dictionary), -4), { i: 2 }, opts && opts.out, opts && opts.dictionary);
+}
+// Default algorithm for compression (used because having a known output size allows faster decompression)
+export { gzip as compress, AsyncGzip as AsyncCompress };
+export { gzipSync as compressSync, Gzip as Compress };
+/**
+ * Streaming GZIP, Zlib, or raw DEFLATE decompression
+ */
+var Decompress = /*#__PURE__*/ (function () {
+    function Decompress(opts, cb) {
+        this.G = Gunzip;
+        this.I = Inflate;
+        this.Z = Unzlib;
+        this.o = StrmOpt.call(this, opts, cb) || {};
+    }
+    /**
+     * Pushes a chunk to be decompressed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Decompress.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (!this.s) {
+            if (this.p && this.p.length) {
+                var n = new u8(this.p.length + chunk.length);
+                n.set(this.p), n.set(chunk, this.p.length);
+            }
+            else
+                this.p = chunk;
+            if (this.p.length > 2) {
+                var _this_2 = this;
+                // enables reuse of this method by AsyncDecompress
+                var cb = function () { _this_2.ondata.apply(_this_2, arguments); };
+                this.s = (this.p[0] == 31 && this.p[1] == 139 && this.p[2] == 8)
+                    ? new this.G(this.o, cb)
+                    : ((this.p[0] & 15) != 8 || (this.p[0] >> 4) > 7 || ((this.p[0] << 8 | this.p[1]) % 31))
+                        ? new this.I(this.o, cb)
+                        : new this.Z(this.o, cb);
+                this.s.push(this.p, final);
+                this.p = null;
+            }
+        }
+        else
+            this.s.push(chunk, final);
+    };
+    return Decompress;
+}());
+export { Decompress };
+/**
+ * Asynchronous streaming GZIP, Zlib, or raw DEFLATE decompression
+ */
+var AsyncDecompress = /*#__PURE__*/ (function () {
+    function AsyncDecompress(opts, cb) {
+        this.G = AsyncGunzip;
+        this.I = AsyncInflate;
+        this.Z = AsyncUnzlib;
+        Decompress.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be decompressed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    AsyncDecompress.prototype.push = function (chunk, final) {
+        Decompress.prototype.push.call(this, chunk, final);
+    };
+    return AsyncDecompress;
+}());
+export { AsyncDecompress };
+export function decompress(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return (data[0] == 31 && data[1] == 139 && data[2] == 8)
+        ? gunzip(data, opts, cb)
+        : ((data[0] & 15) != 8 || (data[0] >> 4) > 7 || ((data[0] << 8 | data[1]) % 31))
+            ? inflate(data, opts, cb)
+            : unzlib(data, opts, cb);
+}
+/**
+ * Expands compressed GZIP, Zlib, or raw DEFLATE data, automatically detecting the format
+ * @param data The data to decompress
+ * @param opts The decompression options
+ * @returns The decompressed version of the data
+ */
+export function decompressSync(data, opts) {
+    return (data[0] == 31 && data[1] == 139 && data[2] == 8)
+        ? gunzipSync(data, opts)
+        : ((data[0] & 15) != 8 || (data[0] >> 4) > 7 || ((data[0] << 8 | data[1]) % 31))
+            ? inflateSync(data, opts)
+            : unzlibSync(data, opts);
+}
+// flatten a directory structure
+var fltn = function (d, p, t, o) {
+    for (var k in d) {
+        var val = d[k], n = p + k, op = o;
+        if (Array.isArray(val))
+            op = mrg(o, val[1]), val = val[0];
+        if (val instanceof u8)
+            t[n] = [val, op];
+        else {
+            t[n += '/'] = [new u8(0), op];
+            fltn(val, n, t, o);
+        }
+    }
+};
+// text encoder
+var te = typeof TextEncoder != 'undefined' && /*#__PURE__*/ new TextEncoder();
+// text decoder
+var td = typeof TextDecoder != 'undefined' && /*#__PURE__*/ new TextDecoder();
+// text decoder stream
+var tds = 0;
+try {
+    td.decode(et, { stream: true });
+    tds = 1;
+}
+catch (e) { }
+// decode UTF8
+var dutf8 = function (d) {
+    for (var r = '', i = 0;;) {
+        var c = d[i++];
+        var eb = (c > 127) + (c > 223) + (c > 239);
+        if (i + eb > d.length)
+            return { s: r, r: slc(d, i - 1) };
+        if (!eb)
+            r += String.fromCharCode(c);
+        else if (eb == 3) {
+            c = ((c & 15) << 18 | (d[i++] & 63) << 12 | (d[i++] & 63) << 6 | (d[i++] & 63)) - 65536,
+                r += String.fromCharCode(55296 | (c >> 10), 56320 | (c & 1023));
+        }
+        else if (eb & 1)
+            r += String.fromCharCode((c & 31) << 6 | (d[i++] & 63));
+        else
+            r += String.fromCharCode((c & 15) << 12 | (d[i++] & 63) << 6 | (d[i++] & 63));
+    }
+};
+/**
+ * Streaming UTF-8 decoding
+ */
+var DecodeUTF8 = /*#__PURE__*/ (function () {
+    /**
+     * Creates a UTF-8 decoding stream
+     * @param cb The callback to call whenever data is decoded
+     */
+    function DecodeUTF8(cb) {
+        this.ondata = cb;
+        if (tds)
+            this.t = new TextDecoder();
+        else
+            this.p = et;
+    }
+    /**
+     * Pushes a chunk to be decoded from UTF-8 binary
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    DecodeUTF8.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        final = !!final;
+        if (this.t) {
+            this.ondata(this.t.decode(chunk, { stream: true }), final);
+            if (final) {
+                if (this.t.decode().length)
+                    err(8);
+                this.t = null;
+            }
+            return;
+        }
+        if (!this.p)
+            err(4);
+        var dat = new u8(this.p.length + chunk.length);
+        dat.set(this.p);
+        dat.set(chunk, this.p.length);
+        var _a = dutf8(dat), s = _a.s, r = _a.r;
+        if (final) {
+            if (r.length)
+                err(8);
+            this.p = null;
+        }
+        else
+            this.p = r;
+        this.ondata(s, final);
+    };
+    return DecodeUTF8;
+}());
+export { DecodeUTF8 };
+/**
+ * Streaming UTF-8 encoding
+ */
+var EncodeUTF8 = /*#__PURE__*/ (function () {
+    /**
+     * Creates a UTF-8 decoding stream
+     * @param cb The callback to call whenever data is encoded
+     */
+    function EncodeUTF8(cb) {
+        this.ondata = cb;
+    }
+    /**
+     * Pushes a chunk to be encoded to UTF-8
+     * @param chunk The string data to push
+     * @param final Whether this is the last chunk
+     */
+    EncodeUTF8.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (this.d)
+            err(4);
+        this.ondata(strToU8(chunk), this.d = final || false);
+    };
+    return EncodeUTF8;
+}());
+export { EncodeUTF8 };
+/**
+ * Converts a string into a Uint8Array for use with compression/decompression methods
+ * @param str The string to encode
+ * @param latin1 Whether or not to interpret the data as Latin-1. This should
+ *               not need to be true unless decoding a binary string.
+ * @returns The string encoded in UTF-8/Latin-1 binary
+ */
+export function strToU8(str, latin1) {
+    if (latin1) {
+        var ar_1 = new u8(str.length);
+        for (var i = 0; i < str.length; ++i)
+            ar_1[i] = str.charCodeAt(i);
+        return ar_1;
+    }
+    if (te)
+        return te.encode(str);
+    var l = str.length;
+    var ar = new u8(str.length + (str.length >> 1));
+    var ai = 0;
+    var w = function (v) { ar[ai++] = v; };
+    for (var i = 0; i < l; ++i) {
+        if (ai + 5 > ar.length) {
+            var n = new u8(ai + 8 + ((l - i) << 1));
+            n.set(ar);
+            ar = n;
+        }
+        var c = str.charCodeAt(i);
+        if (c < 128 || latin1)
+            w(c);
+        else if (c < 2048)
+            w(192 | (c >> 6)), w(128 | (c & 63));
+        else if (c > 55295 && c < 57344)
+            c = 65536 + (c & 1023 << 10) | (str.charCodeAt(++i) & 1023),
+                w(240 | (c >> 18)), w(128 | ((c >> 12) & 63)), w(128 | ((c >> 6) & 63)), w(128 | (c & 63));
+        else
+            w(224 | (c >> 12)), w(128 | ((c >> 6) & 63)), w(128 | (c & 63));
+    }
+    return slc(ar, 0, ai);
+}
+/**
+ * Converts a Uint8Array to a string
+ * @param dat The data to decode to string
+ * @param latin1 Whether or not to interpret the data as Latin-1. This should
+ *               not need to be true unless encoding to binary string.
+ * @returns The original UTF-8/Latin-1 string
+ */
+export function strFromU8(dat, latin1) {
+    if (latin1) {
+        var r = '';
+        for (var i = 0; i < dat.length; i += 16384)
+            r += String.fromCharCode.apply(null, dat.subarray(i, i + 16384));
+        return r;
+    }
+    else if (td) {
+        return td.decode(dat);
+    }
+    else {
+        var _a = dutf8(dat), s = _a.s, r = _a.r;
+        if (r.length)
+            err(8);
+        return s;
+    }
+}
+;
+// deflate bit flag
+var dbf = function (l) { return l == 1 ? 3 : l < 6 ? 2 : l == 9 ? 1 : 0; };
+// skip local zip header
+var slzh = function (d, b) { return b + 30 + b2(d, b + 26) + b2(d, b + 28); };
+// read zip header
+var zh = function (d, b, z) {
+    var fnl = b2(d, b + 28), fn = strFromU8(d.subarray(b + 46, b + 46 + fnl), !(b2(d, b + 8) & 2048)), es = b + 46 + fnl, bs = b4(d, b + 20);
+    var _a = z && bs == 4294967295 ? z64e(d, es) : [bs, b4(d, b + 24), b4(d, b + 42)], sc = _a[0], su = _a[1], off = _a[2];
+    return [b2(d, b + 10), sc, su, fn, es + b2(d, b + 30) + b2(d, b + 32), off];
+};
+// read zip64 extra field
+var z64e = function (d, b) {
+    for (; b2(d, b) != 1; b += 4 + b2(d, b + 2))
+        ;
+    return [b8(d, b + 12), b8(d, b + 4), b8(d, b + 20)];
+};
+// extra field length
+var exfl = function (ex) {
+    var le = 0;
+    if (ex) {
+        for (var k in ex) {
+            var l = ex[k].length;
+            if (l > 65535)
+                err(9);
+            le += l + 4;
+        }
+    }
+    return le;
+};
+// write zip header
+var wzh = function (d, b, f, fn, u, c, ce, co) {
+    var fl = fn.length, ex = f.extra, col = co && co.length;
+    var exl = exfl(ex);
+    wbytes(d, b, ce != null ? 0x2014B50 : 0x4034B50), b += 4;
+    if (ce != null)
+        d[b++] = 20, d[b++] = f.os;
+    d[b] = 20, b += 2; // spec compliance? what's that?
+    d[b++] = (f.flag << 1) | (c < 0 && 8), d[b++] = u && 8;
+    d[b++] = f.compression & 255, d[b++] = f.compression >> 8;
+    var dt = new Date(f.mtime == null ? Date.now() : f.mtime), y = dt.getFullYear() - 1980;
+    if (y < 0 || y > 119)
+        err(10);
+    wbytes(d, b, (y << 25) | ((dt.getMonth() + 1) << 21) | (dt.getDate() << 16) | (dt.getHours() << 11) | (dt.getMinutes() << 5) | (dt.getSeconds() >> 1)), b += 4;
+    if (c != -1) {
+        wbytes(d, b, f.crc);
+        wbytes(d, b + 4, c < 0 ? -c - 2 : c);
+        wbytes(d, b + 8, f.size);
+    }
+    wbytes(d, b + 12, fl);
+    wbytes(d, b + 14, exl), b += 16;
+    if (ce != null) {
+        wbytes(d, b, col);
+        wbytes(d, b + 6, f.attrs);
+        wbytes(d, b + 10, ce), b += 14;
+    }
+    d.set(fn, b);
+    b += fl;
+    if (exl) {
+        for (var k in ex) {
+            var exf = ex[k], l = exf.length;
+            wbytes(d, b, +k);
+            wbytes(d, b + 2, l);
+            d.set(exf, b + 4), b += 4 + l;
+        }
+    }
+    if (col)
+        d.set(co, b), b += col;
+    return b;
+};
+// write zip footer (end of central directory)
+var wzf = function (o, b, c, d, e) {
+    wbytes(o, b, 0x6054B50); // skip disk
+    wbytes(o, b + 8, c);
+    wbytes(o, b + 10, c);
+    wbytes(o, b + 12, d);
+    wbytes(o, b + 16, e);
+};
+/**
+ * A pass-through stream to keep data uncompressed in a ZIP archive.
+ */
+var ZipPassThrough = /*#__PURE__*/ (function () {
+    /**
+     * Creates a pass-through stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     */
+    function ZipPassThrough(filename) {
+        this.filename = filename;
+        this.c = crc();
+        this.size = 0;
+        this.compression = 0;
+    }
+    /**
+     * Processes a chunk and pushes to the output stream. You can override this
+     * method in a subclass for custom behavior, but by default this passes
+     * the data through. You must call this.ondata(err, chunk, final) at some
+     * point in this method.
+     * @param chunk The chunk to process
+     * @param final Whether this is the last chunk
+     */
+    ZipPassThrough.prototype.process = function (chunk, final) {
+        this.ondata(null, chunk, final);
+    };
+    /**
+     * Pushes a chunk to be added. If you are subclassing this with a custom
+     * compression algorithm, note that you must push data from the source
+     * file only, pre-compression.
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    ZipPassThrough.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        this.c.p(chunk);
+        this.size += chunk.length;
+        if (final)
+            this.crc = this.c.d();
+        this.process(chunk, final || false);
+    };
+    return ZipPassThrough;
+}());
+export { ZipPassThrough };
+// I don't extend because TypeScript extension adds 1kB of runtime bloat
+/**
+ * Streaming DEFLATE compression for ZIP archives. Prefer using AsyncZipDeflate
+ * for better performance
+ */
+var ZipDeflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     * @param opts The compression options
+     */
+    function ZipDeflate(filename, opts) {
+        var _this_1 = this;
+        if (!opts)
+            opts = {};
+        ZipPassThrough.call(this, filename);
+        this.d = new Deflate(opts, function (dat, final) {
+            _this_1.ondata(null, dat, final);
+        });
+        this.compression = 8;
+        this.flag = dbf(opts.level);
+    }
+    ZipDeflate.prototype.process = function (chunk, final) {
+        try {
+            this.d.push(chunk, final);
+        }
+        catch (e) {
+            this.ondata(e, null, final);
+        }
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    ZipDeflate.prototype.push = function (chunk, final) {
+        ZipPassThrough.prototype.push.call(this, chunk, final);
+    };
+    return ZipDeflate;
+}());
+export { ZipDeflate };
+/**
+ * Asynchronous streaming DEFLATE compression for ZIP archives
+ */
+var AsyncZipDeflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates an asynchronous DEFLATE stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     * @param opts The compression options
+     */
+    function AsyncZipDeflate(filename, opts) {
+        var _this_1 = this;
+        if (!opts)
+            opts = {};
+        ZipPassThrough.call(this, filename);
+        this.d = new AsyncDeflate(opts, function (err, dat, final) {
+            _this_1.ondata(err, dat, final);
+        });
+        this.compression = 8;
+        this.flag = dbf(opts.level);
+        this.terminate = this.d.terminate;
+    }
+    AsyncZipDeflate.prototype.process = function (chunk, final) {
+        this.d.push(chunk, final);
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    AsyncZipDeflate.prototype.push = function (chunk, final) {
+        ZipPassThrough.prototype.push.call(this, chunk, final);
+    };
+    return AsyncZipDeflate;
+}());
+export { AsyncZipDeflate };
+// TODO: Better tree shaking
+/**
+ * A zippable archive to which files can incrementally be added
+ */
+var Zip = /*#__PURE__*/ (function () {
+    /**
+     * Creates an empty ZIP archive to which files can be added
+     * @param cb The callback to call whenever data for the generated ZIP archive
+     *           is available
+     */
+    function Zip(cb) {
+        this.ondata = cb;
+        this.u = [];
+        this.d = 1;
+    }
+    /**
+     * Adds a file to the ZIP archive
+     * @param file The file stream to add
+     */
+    Zip.prototype.add = function (file) {
+        var _this_1 = this;
+        if (!this.ondata)
+            err(5);
+        // finishing or finished
+        if (this.d & 2)
+            this.ondata(err(4 + (this.d & 1) * 8, 0, 1), null, false);
+        else {
+            var f = strToU8(file.filename), fl_1 = f.length;
+            var com = file.comment, o = com && strToU8(com);
+            var u = fl_1 != file.filename.length || (o && (com.length != o.length));
+            var hl_1 = fl_1 + exfl(file.extra) + 30;
+            if (fl_1 > 65535)
+                this.ondata(err(11, 0, 1), null, false);
+            var header = new u8(hl_1);
+            wzh(header, 0, file, f, u, -1);
+            var chks_1 = [header];
+            var pAll_1 = function () {
+                for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+                    var chk = chks_2[_i];
+                    _this_1.ondata(null, chk, false);
+                }
+                chks_1 = [];
+            };
+            var tr_1 = this.d;
+            this.d = 0;
+            var ind_1 = this.u.length;
+            var uf_1 = mrg(file, {
+                f: f,
+                u: u,
+                o: o,
+                t: function () {
+                    if (file.terminate)
+                        file.terminate();
+                },
+                r: function () {
+                    pAll_1();
+                    if (tr_1) {
+                        var nxt = _this_1.u[ind_1 + 1];
+                        if (nxt)
+                            nxt.r();
+                        else
+                            _this_1.d = 1;
+                    }
+                    tr_1 = 1;
+                }
+            });
+            var cl_1 = 0;
+            file.ondata = function (err, dat, final) {
+                if (err) {
+                    _this_1.ondata(err, dat, final);
+                    _this_1.terminate();
+                }
+                else {
+                    cl_1 += dat.length;
+                    chks_1.push(dat);
+                    if (final) {
+                        var dd = new u8(16);
+                        wbytes(dd, 0, 0x8074B50);
+                        wbytes(dd, 4, file.crc);
+                        wbytes(dd, 8, cl_1);
+                        wbytes(dd, 12, file.size);
+                        chks_1.push(dd);
+                        uf_1.c = cl_1, uf_1.b = hl_1 + cl_1 + 16, uf_1.crc = file.crc, uf_1.size = file.size;
+                        if (tr_1)
+                            uf_1.r();
+                        tr_1 = 1;
+                    }
+                    else if (tr_1)
+                        pAll_1();
+                }
+            };
+            this.u.push(uf_1);
+        }
+    };
+    /**
+     * Ends the process of adding files and prepares to emit the final chunks.
+     * This *must* be called after adding all desired files for the resulting
+     * ZIP file to work properly.
+     */
+    Zip.prototype.end = function () {
+        var _this_1 = this;
+        if (this.d & 2) {
+            this.ondata(err(4 + (this.d & 1) * 8, 0, 1), null, true);
+            return;
+        }
+        if (this.d)
+            this.e();
+        else
+            this.u.push({
+                r: function () {
+                    if (!(_this_1.d & 1))
+                        return;
+                    _this_1.u.splice(-1, 1);
+                    _this_1.e();
+                },
+                t: function () { }
+            });
+        this.d = 3;
+    };
+    Zip.prototype.e = function () {
+        var bt = 0, l = 0, tl = 0;
+        for (var _i = 0, _a = this.u; _i < _a.length; _i++) {
+            var f = _a[_i];
+            tl += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0);
+        }
+        var out = new u8(tl + 22);
+        for (var _b = 0, _c = this.u; _b < _c.length; _b++) {
+            var f = _c[_b];
+            wzh(out, bt, f, f.f, f.u, -f.c - 2, l, f.o);
+            bt += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0), l += f.b;
+        }
+        wzf(out, bt, this.u.length, tl, l);
+        this.ondata(null, out, true);
+        this.d = 2;
+    };
+    /**
+     * A method to terminate any internal workers used by the stream. Subsequent
+     * calls to add() will fail.
+     */
+    Zip.prototype.terminate = function () {
+        for (var _i = 0, _a = this.u; _i < _a.length; _i++) {
+            var f = _a[_i];
+            f.t();
+        }
+        this.d = 2;
+    };
+    return Zip;
+}());
+export { Zip };
+export function zip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    var r = {};
+    fltn(data, '', r, opts);
+    var k = Object.keys(r);
+    var lft = k.length, o = 0, tot = 0;
+    var slft = lft, files = new Array(lft);
+    var term = [];
+    var tAll = function () {
+        for (var i = 0; i < term.length; ++i)
+            term[i]();
+    };
+    var cbd = function (a, b) {
+        mt(function () { cb(a, b); });
+    };
+    mt(function () { cbd = cb; });
+    var cbf = function () {
+        var out = new u8(tot + 22), oe = o, cdl = tot - o;
+        tot = 0;
+        for (var i = 0; i < slft; ++i) {
+            var f = files[i];
+            try {
+                var l = f.c.length;
+                wzh(out, tot, f, f.f, f.u, l);
+                var badd = 30 + f.f.length + exfl(f.extra);
+                var loc = tot + badd;
+                out.set(f.c, loc);
+                wzh(out, o, f, f.f, f.u, l, tot, f.m), o += 16 + badd + (f.m ? f.m.length : 0), tot = loc + l;
+            }
+            catch (e) {
+                return cbd(e, null);
+            }
+        }
+        wzf(out, o, files.length, cdl, oe);
+        cbd(null, out);
+    };
+    if (!lft)
+        cbf();
+    var _loop_1 = function (i) {
+        var fn = k[i];
+        var _a = r[fn], file = _a[0], p = _a[1];
+        var c = crc(), size = file.length;
+        c.p(file);
+        var f = strToU8(fn), s = f.length;
+        var com = p.comment, m = com && strToU8(com), ms = m && m.length;
+        var exl = exfl(p.extra);
+        var compression = p.level == 0 ? 0 : 8;
+        var cbl = function (e, d) {
+            if (e) {
+                tAll();
+                cbd(e, null);
+            }
+            else {
+                var l = d.length;
+                files[i] = mrg(p, {
+                    size: size,
+                    crc: c.d(),
+                    c: d,
+                    f: f,
+                    m: m,
+                    u: s != fn.length || (m && (com.length != ms)),
+                    compression: compression
+                });
+                o += 30 + s + exl + l;
+                tot += 76 + 2 * (s + exl) + (ms || 0) + l;
+                if (!--lft)
+                    cbf();
+            }
+        };
+        if (s > 65535)
+            cbl(err(11, 0, 1), null);
+        if (!compression)
+            cbl(null, file);
+        else if (size < 160000) {
+            try {
+                cbl(null, deflateSync(file, p));
+            }
+            catch (e) {
+                cbl(e, null);
+            }
+        }
+        else
+            term.push(deflate(file, p, cbl));
+    };
+    // Cannot use lft because it can decrease
+    for (var i = 0; i < slft; ++i) {
+        _loop_1(i);
+    }
+    return tAll;
+}
+/**
+ * Synchronously creates a ZIP file. Prefer using `zip` for better performance
+ * with more than one file.
+ * @param data The directory structure for the ZIP archive
+ * @param opts The main options, merged with per-file options
+ * @returns The generated ZIP archive
+ */
+export function zipSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var r = {};
+    var files = [];
+    fltn(data, '', r, opts);
+    var o = 0;
+    var tot = 0;
+    for (var fn in r) {
+        var _a = r[fn], file = _a[0], p = _a[1];
+        var compression = p.level == 0 ? 0 : 8;
+        var f = strToU8(fn), s = f.length;
+        var com = p.comment, m = com && strToU8(com), ms = m && m.length;
+        var exl = exfl(p.extra);
+        if (s > 65535)
+            err(11);
+        var d = compression ? deflateSync(file, p) : file, l = d.length;
+        var c = crc();
+        c.p(file);
+        files.push(mrg(p, {
+            size: file.length,
+            crc: c.d(),
+            c: d,
+            f: f,
+            m: m,
+            u: s != fn.length || (m && (com.length != ms)),
+            o: o,
+            compression: compression
+        }));
+        o += 30 + s + exl + l;
+        tot += 76 + 2 * (s + exl) + (ms || 0) + l;
+    }
+    var out = new u8(tot + 22), oe = o, cdl = tot - o;
+    for (var i = 0; i < files.length; ++i) {
+        var f = files[i];
+        wzh(out, f.o, f, f.f, f.u, f.c.length);
+        var badd = 30 + f.f.length + exfl(f.extra);
+        out.set(f.c, f.o + badd);
+        wzh(out, o, f, f.f, f.u, f.c.length, f.o, f.m), o += 16 + badd + (f.m ? f.m.length : 0);
+    }
+    wzf(out, o, files.length, cdl, oe);
+    return out;
+}
+/**
+ * Streaming pass-through decompression for ZIP archives
+ */
+var UnzipPassThrough = /*#__PURE__*/ (function () {
+    function UnzipPassThrough() {
+    }
+    UnzipPassThrough.prototype.push = function (data, final) {
+        this.ondata(null, data, final);
+    };
+    UnzipPassThrough.compression = 0;
+    return UnzipPassThrough;
+}());
+export { UnzipPassThrough };
+/**
+ * Streaming DEFLATE decompression for ZIP archives. Prefer AsyncZipInflate for
+ * better performance.
+ */
+var UnzipInflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE decompression that can be used in ZIP archives
+     */
+    function UnzipInflate() {
+        var _this_1 = this;
+        this.i = new Inflate(function (dat, final) {
+            _this_1.ondata(null, dat, final);
+        });
+    }
+    UnzipInflate.prototype.push = function (data, final) {
+        try {
+            this.i.push(data, final);
+        }
+        catch (e) {
+            this.ondata(e, null, final);
+        }
+    };
+    UnzipInflate.compression = 8;
+    return UnzipInflate;
+}());
+export { UnzipInflate };
+/**
+ * Asynchronous streaming DEFLATE decompression for ZIP archives
+ */
+var AsyncUnzipInflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE decompression that can be used in ZIP archives
+     */
+    function AsyncUnzipInflate(_, sz) {
+        var _this_1 = this;
+        if (sz < 320000) {
+            this.i = new Inflate(function (dat, final) {
+                _this_1.ondata(null, dat, final);
+            });
+        }
+        else {
+            this.i = new AsyncInflate(function (err, dat, final) {
+                _this_1.ondata(err, dat, final);
+            });
+            this.terminate = this.i.terminate;
+        }
+    }
+    AsyncUnzipInflate.prototype.push = function (data, final) {
+        if (this.i.terminate)
+            data = slc(data, 0);
+        this.i.push(data, final);
+    };
+    AsyncUnzipInflate.compression = 8;
+    return AsyncUnzipInflate;
+}());
+export { AsyncUnzipInflate };
+/**
+ * A ZIP archive decompression stream that emits files as they are discovered
+ */
+var Unzip = /*#__PURE__*/ (function () {
+    /**
+     * Creates a ZIP decompression stream
+     * @param cb The callback to call whenever a file in the ZIP archive is found
+     */
+    function Unzip(cb) {
+        this.onfile = cb;
+        this.k = [];
+        this.o = {
+            0: UnzipPassThrough
+        };
+        this.p = et;
+    }
+    /**
+     * Pushes a chunk to be unzipped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Unzip.prototype.push = function (chunk, final) {
+        var _this_1 = this;
+        if (!this.onfile)
+            err(5);
+        if (!this.p)
+            err(4);
+        if (this.c > 0) {
+            var len = Math.min(this.c, chunk.length);
+            var toAdd = chunk.subarray(0, len);
+            this.c -= len;
+            if (this.d)
+                this.d.push(toAdd, !this.c);
+            else
+                this.k[0].push(toAdd);
+            chunk = chunk.subarray(len);
+            if (chunk.length)
+                return this.push(chunk, final);
+        }
+        else {
+            var f = 0, i = 0, is = void 0, buf = void 0;
+            if (!this.p.length)
+                buf = chunk;
+            else if (!chunk.length)
+                buf = this.p;
+            else {
+                buf = new u8(this.p.length + chunk.length);
+                buf.set(this.p), buf.set(chunk, this.p.length);
+            }
+            var l = buf.length, oc = this.c, add = oc && this.d;
+            var _loop_2 = function () {
+                var _a;
+                var sig = b4(buf, i);
+                if (sig == 0x4034B50) {
+                    f = 1, is = i;
+                    this_1.d = null;
+                    this_1.c = 0;
+                    var bf = b2(buf, i + 6), cmp_1 = b2(buf, i + 8), u = bf & 2048, dd = bf & 8, fnl = b2(buf, i + 26), es = b2(buf, i + 28);
+                    if (l > i + 30 + fnl + es) {
+                        var chks_3 = [];
+                        this_1.k.unshift(chks_3);
+                        f = 2;
+                        var sc_1 = b4(buf, i + 18), su_1 = b4(buf, i + 22);
+                        var fn_1 = strFromU8(buf.subarray(i + 30, i += 30 + fnl), !u);
+                        if (sc_1 == 4294967295) {
+                            _a = dd ? [-2] : z64e(buf, i), sc_1 = _a[0], su_1 = _a[1];
+                        }
+                        else if (dd)
+                            sc_1 = -1;
+                        i += es;
+                        this_1.c = sc_1;
+                        var d_1;
+                        var file_1 = {
+                            name: fn_1,
+                            compression: cmp_1,
+                            start: function () {
+                                if (!file_1.ondata)
+                                    err(5);
+                                if (!sc_1)
+                                    file_1.ondata(null, et, true);
+                                else {
+                                    var ctr = _this_1.o[cmp_1];
+                                    if (!ctr)
+                                        file_1.ondata(err(14, 'unknown compression type ' + cmp_1, 1), null, false);
+                                    d_1 = sc_1 < 0 ? new ctr(fn_1) : new ctr(fn_1, sc_1, su_1);
+                                    d_1.ondata = function (err, dat, final) { file_1.ondata(err, dat, final); };
+                                    for (var _i = 0, chks_4 = chks_3; _i < chks_4.length; _i++) {
+                                        var dat = chks_4[_i];
+                                        d_1.push(dat, false);
+                                    }
+                                    if (_this_1.k[0] == chks_3 && _this_1.c)
+                                        _this_1.d = d_1;
+                                    else
+                                        d_1.push(et, true);
+                                }
+                            },
+                            terminate: function () {
+                                if (d_1 && d_1.terminate)
+                                    d_1.terminate();
+                            }
+                        };
+                        if (sc_1 >= 0)
+                            file_1.size = sc_1, file_1.originalSize = su_1;
+                        this_1.onfile(file_1);
+                    }
+                    return "break";
+                }
+                else if (oc) {
+                    if (sig == 0x8074B50) {
+                        is = i += 12 + (oc == -2 && 8), f = 3, this_1.c = 0;
+                        return "break";
+                    }
+                    else if (sig == 0x2014B50) {
+                        is = i -= 4, f = 3, this_1.c = 0;
+                        return "break";
+                    }
+                }
+            };
+            var this_1 = this;
+            for (; i < l - 4; ++i) {
+                var state_1 = _loop_2();
+                if (state_1 === "break")
+                    break;
+            }
+            this.p = et;
+            if (oc < 0) {
+                var dat = f ? buf.subarray(0, is - 12 - (oc == -2 && 8) - (b4(buf, is - 16) == 0x8074B50 && 4)) : buf.subarray(0, i);
+                if (add)
+                    add.push(dat, !!f);
+                else
+                    this.k[+(f == 2)].push(dat);
+            }
+            if (f & 2)
+                return this.push(buf.subarray(i), final);
+            this.p = buf.subarray(i);
+        }
+        if (final) {
+            if (this.c)
+                err(13);
+            this.p = null;
+        }
+    };
+    /**
+     * Registers a decoder with the stream, allowing for files compressed with
+     * the compression type provided to be expanded correctly
+     * @param decoder The decoder constructor
+     */
+    Unzip.prototype.register = function (decoder) {
+        this.o[decoder.compression] = decoder;
+    };
+    return Unzip;
+}());
+export { Unzip };
+var mt = typeof queueMicrotask == 'function' ? queueMicrotask : typeof setTimeout == 'function' ? setTimeout : function (fn) { fn(); };
+export function unzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    var term = [];
+    var tAll = function () {
+        for (var i = 0; i < term.length; ++i)
+            term[i]();
+    };
+    var files = {};
+    var cbd = function (a, b) {
+        mt(function () { cb(a, b); });
+    };
+    mt(function () { cbd = cb; });
+    var e = data.length - 22;
+    for (; b4(data, e) != 0x6054B50; --e) {
+        if (!e || data.length - e > 65558) {
+            cbd(err(13, 0, 1), null);
+            return tAll;
+        }
+    }
+    ;
+    var lft = b2(data, e + 8);
+    if (lft) {
+        var c = lft;
+        var o = b4(data, e + 16);
+        var z = o == 4294967295 || c == 65535;
+        if (z) {
+            var ze = b4(data, e - 12);
+            z = b4(data, ze) == 0x6064B50;
+            if (z) {
+                c = lft = b4(data, ze + 32);
+                o = b4(data, ze + 48);
+            }
+        }
+        var fltr = opts && opts.filter;
+        var _loop_3 = function (i) {
+            var _a = zh(data, o, z), c_1 = _a[0], sc = _a[1], su = _a[2], fn = _a[3], no = _a[4], off = _a[5], b = slzh(data, off);
+            o = no;
+            var cbl = function (e, d) {
+                if (e) {
+                    tAll();
+                    cbd(e, null);
+                }
+                else {
+                    if (d)
+                        files[fn] = d;
+                    if (!--lft)
+                        cbd(null, files);
+                }
+            };
+            if (!fltr || fltr({
+                name: fn,
+                size: sc,
+                originalSize: su,
+                compression: c_1
+            })) {
+                if (!c_1)
+                    cbl(null, slc(data, b, b + sc));
+                else if (c_1 == 8) {
+                    var infl = data.subarray(b, b + sc);
+                    if (sc < 320000) {
+                        try {
+                            cbl(null, inflateSync(infl, { out: new u8(su) }));
+                        }
+                        catch (e) {
+                            cbl(e, null);
+                        }
+                    }
+                    else
+                        term.push(inflate(infl, { size: su }, cbl));
+                }
+                else
+                    cbl(err(14, 'unknown compression type ' + c_1, 1), null);
+            }
+            else
+                cbl(null, null);
+        };
+        for (var i = 0; i < c; ++i) {
+            _loop_3(i);
+        }
+    }
+    else
+        cbd(null, {});
+    return tAll;
+}
+/**
+ * Synchronously decompresses a ZIP archive. Prefer using `unzip` for better
+ * performance with more than one file.
+ * @param data The raw compressed ZIP file
+ * @param opts The ZIP extraction options
+ * @returns The decompressed files
+ */
+export function unzipSync(data, opts) {
+    var files = {};
+    var e = data.length - 22;
+    for (; b4(data, e) != 0x6054B50; --e) {
+        if (!e || data.length - e > 65558)
+            err(13);
+    }
+    ;
+    var c = b2(data, e + 8);
+    if (!c)
+        return {};
+    var o = b4(data, e + 16);
+    var z = o == 4294967295 || c == 65535;
+    if (z) {
+        var ze = b4(data, e - 12);
+        z = b4(data, ze) == 0x6064B50;
+        if (z) {
+            c = b4(data, ze + 32);
+            o = b4(data, ze + 48);
+        }
+    }
+    var fltr = opts && opts.filter;
+    for (var i = 0; i < c; ++i) {
+        var _a = zh(data, o, z), c_2 = _a[0], sc = _a[1], su = _a[2], fn = _a[3], no = _a[4], off = _a[5], b = slzh(data, off);
+        o = no;
+        if (!fltr || fltr({
+            name: fn,
+            size: sc,
+            originalSize: su,
+            compression: c_2
+        })) {
+            if (!c_2)
+                files[fn] = slc(data, b, b + sc);
+            else if (c_2 == 8)
+                files[fn] = inflateSync(data.subarray(b, b + sc), { out: new u8(su) });
+            else
+                err(14, 'unknown compression type ' + c_2);
+        }
+    }
+    return files;
+}

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -5,8 +5,10 @@ body { display: flex; flex-direction: column; min-height: 100vh; }
 .topbar h1 { font-size: 1.1rem; margin: 0; font-weight: 600; }
 .toolbar button { margin-right: 0.5rem; }
 .toolbar button.active { font-weight: 700; }
-.app-messages { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; padding: 0.5rem 1rem; border-bottom: 1px solid #e5e7eb; background: #f1f5f9; color: #0f172a; }
-.app-messages__text { flex: 1; }
+.app-messages { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; padding: 0.5rem 1rem; border-bottom: 1px solid #e5e7eb; background: #f1f5f9; color: #0f172a; }
+.app-messages__content { display: grid; gap: 0.5rem; flex: 1; }
+.app-messages__text { flex: 1; font-weight: 600; }
+.app-messages__details { display: grid; gap: 0.5rem; }
 .app-messages__dismiss { border: none; background: transparent; font-size: 1.25rem; line-height: 1; cursor: pointer; color: inherit; padding: 0.25rem; }
 .layout { flex: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 0; }
 .pane { border-right: 1px solid #eee; padding: 0.75rem; overflow: auto; }
@@ -41,6 +43,16 @@ body { display: flex; flex-direction: column; min-height: 100vh; }
 .dialogue-line textarea { width: 100%; }
 .audio-info { font-size: 0.85rem; color: #374151; display: flex; align-items: center; gap: 0.5rem; }
 .player-panel { display: grid; gap: 1rem; }
+.player-history { display: grid; gap: 0.5rem; padding: 0.75rem 1rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 10px; }
+.player-history-title { margin: 0; font-size: 0.95rem; color: #1f2937; }
+.player-history-nav { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.player-history-nav button { padding: 0.4rem 0.75rem; font-size: 0.95rem; }
+.player-history-nav button:disabled { opacity: 0.5; cursor: not-allowed; }
+.player-history-list { list-style: none; display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0; padding: 0; }
+.player-history-list li { margin: 0; }
+.player-history-entry { padding: 0.35rem 0.75rem; border: 1px solid #d1d5db; border-radius: 999px; background: #fff; color: #111827; cursor: pointer; transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease; }
+.player-history-entry:disabled { cursor: default; opacity: 0.85; }
+.player-history-entry[aria-current] { background: #1d4ed8; border-color: #1d4ed8; color: #fff; cursor: default; }
 .player-dialogue { display: grid; gap: 0.75rem; padding: 1rem; background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; }
 .player-dialogue-line { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .audio-play { padding: 0.25rem 0.5rem; }

--- a/tests/player-background-audio.test.mjs
+++ b/tests/player-background-audio.test.mjs
@@ -1,0 +1,240 @@
+class StubElement {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this.eventListeners = {};
+    this.attributes = {};
+    this._innerHTML = '';
+    this._textContent = '';
+    this.className = '';
+    this.dataset = {};
+    this.disabled = false;
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  append(...nodes) {
+    nodes.forEach(node => {
+      if (node instanceof StubElement) {
+        this.appendChild(node);
+      }
+    });
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  set textContent(value) {
+    this._textContent = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    if (this.children.length) {
+      return this.children.map(child => child.textContent || '').join('');
+    }
+    return this._textContent;
+  }
+
+  addEventListener(type, handler) {
+    if (!this.eventListeners[type]) {
+      this.eventListeners[type] = [];
+    }
+    this.eventListeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this.eventListeners[type]) {
+      return;
+    }
+    this.eventListeners[type] = this.eventListeners[type].filter(cb => cb !== handler);
+  }
+
+  dispatchEvent(type, event = {}) {
+    const handlers = this.eventListeners[type] || [];
+    handlers.forEach(handler => handler({ ...event, target: event.target ?? this }));
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+}
+
+class StubDocument {
+  constructor() {
+    this.body = new StubElement('body');
+  }
+
+  createElement(tagName) {
+    return new StubElement(tagName);
+  }
+}
+
+class FakeAudio {
+  constructor(src) {
+    this.src = src;
+    this.loop = false;
+    this.paused = true;
+    this.currentTime = 0;
+    this._listeners = {};
+    FakeAudio.instances.push(this);
+  }
+
+  play() {
+    this.paused = false;
+    FakeAudio.playCalls.push(this.src);
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.paused = true;
+    FakeAudio.pauseCalls.push(this.src);
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      return;
+    }
+    this._listeners[type] = this._listeners[type].filter(cb => cb !== handler);
+  }
+}
+
+FakeAudio.instances = [];
+FakeAudio.playCalls = [];
+FakeAudio.pauseCalls = [];
+
+function resetAudioSpies() {
+  FakeAudio.instances.length = 0;
+  FakeAudio.playCalls.length = 0;
+  FakeAudio.pauseCalls.length = 0;
+}
+
+function logResult(label, condition) {
+  const status = condition ? 'OK' : 'FAIL';
+  console.log(`${status}: ${label}`);
+}
+
+function findByText(root, text) {
+  if (!root) {
+    return null;
+  }
+  const hasChildren = (root.children?.length || 0) > 0;
+  if (root.textContent === text && (!hasChildren || root.tagName === 'button')) {
+    return root;
+  }
+  for (const child of root.children || []) {
+    const match = findByText(child, text);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+function cloneProject(project) {
+  return {
+    meta: { ...project.meta },
+    scenes: project.scenes.map(scene => ({
+      ...scene,
+      image: scene.image ? { ...scene.image } : null,
+      backgroundAudio: scene.backgroundAudio ? { ...scene.backgroundAudio } : null,
+      dialogue: scene.dialogue.map(line => ({ ...line })),
+      choices: scene.choices.map(choice => ({ ...choice })),
+    })),
+  };
+}
+
+globalThis.document = new StubDocument();
+globalThis.Audio = FakeAudio;
+
+const { renderPlayer } = await import('../public/scripts/player/player.js');
+const { Store } = await import('../public/scripts/state.js');
+const { SceneType } = await import('../public/scripts/model.js');
+
+resetAudioSpies();
+
+const store = new Store();
+const project = {
+  meta: { title: 'Audio Test' },
+  scenes: [
+    {
+      id: 'start-1',
+      type: SceneType.START,
+      image: null,
+      backgroundAudio: { name: 'Loop', objectUrl: 'bg-loop.ogg' },
+      dialogue: [{ text: 'Welcome', audio: null }],
+      choices: [
+        { id: 'choice-1', label: 'To End', nextSceneId: 'end-1' },
+      ],
+      autoNextSceneId: null,
+      notes: '',
+    },
+    {
+      id: 'end-1',
+      type: SceneType.END,
+      image: null,
+      backgroundAudio: null,
+      dialogue: [{ text: 'The end', audio: null }],
+      choices: [],
+      autoNextSceneId: null,
+      notes: '',
+    },
+  ],
+};
+
+store.set({ project });
+
+const stageHost = new StubElement('div');
+const uiHost = new StubElement('div');
+
+const cleanup = renderPlayer(store, stageHost, uiHost, () => {});
+
+logResult('Background idle before Begin Story', FakeAudio.playCalls.length === 0);
+
+const startButton = findByText(uiHost, 'Begin Story');
+logResult('Begin Story button renders', Boolean(startButton));
+if (startButton) {
+  startButton.dispatchEvent('click');
+}
+
+const backgroundInstance = FakeAudio.instances[0] ?? null;
+logResult('Background track plays after Begin Story', FakeAudio.playCalls[0] === 'bg-loop.ogg');
+logResult('Background track loops enabled', backgroundInstance?.loop === true);
+logResult('Background track playing', backgroundInstance?.paused === false);
+
+const initialPlayCount = FakeAudio.playCalls.length;
+
+const clonedProject = cloneProject(store.get().project);
+store.set({ project: clonedProject });
+
+logResult(
+  'Background track persists across re-render',
+  FakeAudio.playCalls.length === initialPlayCount && FakeAudio.instances[0] === backgroundInstance && backgroundInstance?.paused === false,
+);
+
+const choiceButton = findByText(uiHost, 'To End');
+logResult('Choice button renders', Boolean(choiceButton));
+if (choiceButton) {
+  choiceButton.dispatchEvent('click');
+}
+
+logResult('Background track stops when leaving scene', FakeAudio.pauseCalls.includes('bg-loop.ogg'));
+logResult('Background track paused state after stop', backgroundInstance?.paused === true);
+
+cleanup();

--- a/tests/player-history.test.mjs
+++ b/tests/player-history.test.mjs
@@ -1,0 +1,283 @@
+class StubElement {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this.eventListeners = {};
+    this.attributes = {};
+    this.dataset = {};
+    this.disabled = false;
+    this.type = '';
+    this.className = '';
+    this.value = '';
+    this._innerHTML = '';
+    this._textContent = '';
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  append(...nodes) {
+    nodes.forEach(node => {
+      if (node instanceof StubElement) {
+        this.appendChild(node);
+      }
+    });
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  set textContent(value) {
+    this._textContent = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    if (this.children.length) {
+      return this.children.map(child => child.textContent || '').join('');
+    }
+    return this._textContent;
+  }
+
+  addEventListener(type, handler) {
+    if (!this.eventListeners[type]) {
+      this.eventListeners[type] = [];
+    }
+    this.eventListeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this.eventListeners[type]) {
+      return;
+    }
+    this.eventListeners[type] = this.eventListeners[type].filter(cb => cb !== handler);
+  }
+
+  dispatchEvent(type, event = {}) {
+    const handlers = this.eventListeners[type] || [];
+    const payload = { ...event };
+    if (!payload.target) {
+      payload.target = this;
+    }
+    handlers.forEach(handler => handler(payload));
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+
+  getAttribute(name) {
+    return this.attributes[name];
+  }
+}
+
+class StubDocument {
+  constructor() {
+    this.body = new StubElement('body');
+  }
+
+  createElement(tagName) {
+    return new StubElement(tagName);
+  }
+}
+
+globalThis.document = new StubDocument();
+
+globalThis.Audio = class {
+  constructor() {}
+  play() { return Promise.resolve(); }
+  pause() {}
+  addEventListener() {}
+  removeEventListener() {}
+};
+
+function findElement(root, predicate) {
+  if (!root) {
+    return null;
+  }
+  if (predicate(root)) {
+    return root;
+  }
+  for (const child of root.children || []) {
+    const match = findElement(child, predicate);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+function findButtonByText(root, text) {
+  return findElement(root, el => el.tagName === 'button' && el.textContent === text);
+}
+
+function getHistoryButtons(root) {
+  const list = findElement(root, el => (el.className || '') === 'player-history-list');
+  if (!list) {
+    return [];
+  }
+  const buttons = [];
+  for (const item of list.children || []) {
+    for (const child of item.children || []) {
+      if (child.tagName === 'button') {
+        buttons.push(child);
+      }
+    }
+  }
+  return buttons;
+}
+
+function logResult(label, condition) {
+  const status = condition ? 'OK' : 'FAIL';
+  console.log(`${status}: ${label}`);
+}
+
+const { renderPlayer } = await import('../public/scripts/player/player.js');
+const { Store } = await import('../public/scripts/state.js');
+const { SceneType } = await import('../public/scripts/model.js');
+
+const store = new Store();
+
+const project = {
+  meta: { title: 'History Demo' },
+  scenes: [
+    {
+      id: 'start',
+      type: SceneType.START,
+      image: null,
+      backgroundAudio: null,
+      dialogue: [{ text: 'Opening scene', audio: null }],
+      choices: [
+        { id: 'c1', label: 'To middle', nextSceneId: 'middle' },
+        { id: 'c2', label: 'Alternate path', nextSceneId: 'alt' },
+      ],
+      autoNextSceneId: null,
+      notes: '',
+    },
+    {
+      id: 'middle',
+      type: SceneType.INTERMEDIATE,
+      image: null,
+      backgroundAudio: null,
+      dialogue: [{ text: 'Middle scene', audio: null }],
+      choices: [
+        { id: 'c3', label: 'To end', nextSceneId: 'end' },
+      ],
+      autoNextSceneId: null,
+      notes: '',
+    },
+    {
+      id: 'alt',
+      type: SceneType.INTERMEDIATE,
+      image: null,
+      backgroundAudio: null,
+      dialogue: [{ text: 'Alternate route', audio: null }],
+      choices: [
+        { id: 'c4', label: 'To end', nextSceneId: 'end' },
+      ],
+      autoNextSceneId: null,
+      notes: '',
+    },
+    {
+      id: 'end',
+      type: SceneType.END,
+      image: null,
+      backgroundAudio: null,
+      dialogue: [{ text: 'The end', audio: null }],
+      choices: [],
+      autoNextSceneId: null,
+      notes: '',
+    },
+  ],
+};
+
+store.set({ project });
+
+const stageHost = new StubElement('div');
+const uiHost = new StubElement('div');
+
+const cleanup = renderPlayer(store, stageHost, uiHost, () => {});
+
+const beginButton = findButtonByText(uiHost, 'Begin Story');
+logResult('Begin Story button renders', Boolean(beginButton));
+if (beginButton) {
+  beginButton.dispatchEvent('click');
+}
+
+let historyButtons = getHistoryButtons(uiHost);
+logResult('History starts with single entry', historyButtons.length === 1);
+logResult(
+  'Initial entry marked current',
+  historyButtons.length === 1 && historyButtons[0].disabled && historyButtons[0].getAttribute('aria-current') === 'step',
+);
+
+let backButton = findElement(uiHost, el => (el.className || '') === 'player-history-back');
+logResult('Back button disabled at start', Boolean(backButton?.disabled));
+
+const toMiddle = findButtonByText(uiHost, 'To middle');
+if (toMiddle) {
+  toMiddle.dispatchEvent('click');
+}
+
+historyButtons = getHistoryButtons(uiHost);
+logResult(
+  'Second scene appended to history',
+  historyButtons.length === 2 && historyButtons[1]?.dataset?.sceneId === 'middle',
+);
+
+backButton = findElement(uiHost, el => (el.className || '') === 'player-history-back');
+logResult('Back button enabled after branching', Boolean(backButton) && backButton.disabled === false);
+if (backButton) {
+  backButton.dispatchEvent('click');
+}
+
+let forwardButton = findElement(uiHost, el => (el.className || '') === 'player-history-forward');
+logResult('Forward available after going back', Boolean(forwardButton) && forwardButton.disabled === false);
+
+const altChoice = findButtonByText(uiHost, 'Alternate path');
+if (altChoice) {
+  altChoice.dispatchEvent('click');
+}
+
+historyButtons = getHistoryButtons(uiHost);
+logResult(
+  'Forward history trimmed on new branch',
+  historyButtons.length === 2 && historyButtons[1]?.dataset?.sceneId === 'alt',
+);
+
+const toEnd = findButtonByText(uiHost, 'To end');
+if (toEnd) {
+  toEnd.dispatchEvent('click');
+}
+
+historyButtons = getHistoryButtons(uiHost);
+logResult('End scene added to history', historyButtons.length === 3 && historyButtons[2]?.dataset?.sceneId === 'end');
+
+const jumpToStart = historyButtons[0];
+if (jumpToStart) {
+  jumpToStart.dispatchEvent('click');
+}
+
+forwardButton = findElement(uiHost, el => (el.className || '') === 'player-history-forward');
+logResult('Forward retained after jump', Boolean(forwardButton) && forwardButton.disabled === false);
+
+const toMiddleAgain = findButtonByText(uiHost, 'To middle');
+if (toMiddleAgain) {
+  toMiddleAgain.dispatchEvent('click');
+}
+
+historyButtons = getHistoryButtons(uiHost);
+logResult(
+  'Branching after jump clears future entries',
+  historyButtons.length === 2 && historyButtons[1]?.dataset?.sceneId === 'middle',
+);
+
+cleanup();

--- a/tests/player-play-all.test.mjs
+++ b/tests/player-play-all.test.mjs
@@ -187,7 +187,7 @@ logResult('First clip starts playback', FakeAudio.playCalls[0] === 'audio-1.ogg'
 FakeAudio.instances[0].trigger('ended');
 logResult('Second clip starts after first ends', FakeAudio.playCalls[1] === 'audio-2.ogg');
 
-FakeAudio.instances[1].trigger('ended');
+FakeAudio.instances[0].trigger('ended');
 logResult('Button resets after final clip', playAllButton.textContent === '▶️ Play all');
 
 // Test: repeat click stops and restart works

--- a/tests/storage-persistence.test.mjs
+++ b/tests/storage-persistence.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { Store } from '../public/scripts/state.js';
+import { createProject, createScene, SceneType } from '../public/scripts/model.js';
+import {
+  serializeProject,
+  hydrateProject,
+  revokeProjectObjectUrls,
+  setupPersistence,
+  createProjectArchive,
+  importProject,
+} from '../public/scripts/storage.js';
+import { unzip } from '../public/scripts/utils/zip.js';
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+const revokedUrls = [];
+let urlCounter = 0;
+
+URL.createObjectURL = (blob) => {
+  assert.ok(blob instanceof Blob, 'serialize/hydrate should pass Blob instances to URL.createObjectURL');
+  const url = `blob:test-${urlCounter += 1}`;
+  return url;
+};
+
+URL.revokeObjectURL = (url) => {
+  revokedUrls.push(url);
+};
+
+const imageBlob = new Blob(['image-data'], { type: 'text/plain' });
+const audioBlob = new Blob(['audio-data'], { type: 'audio/mpeg' });
+
+const sourceProject = createProject({
+  meta: { title: 'Persistent Adventure', version: 3 },
+  scenes: [createScene({
+    id: 'scene-1',
+    type: SceneType.START,
+    image: { name: 'cover.png', objectUrl: 'blob:legacy-img', blob: imageBlob },
+    backgroundAudio: { name: 'bg.mp3', objectUrl: 'blob:legacy-bg', blob: audioBlob },
+    dialogue: [
+      { text: 'Welcome!', audio: { name: 'line.mp3', objectUrl: 'blob:legacy-line', blob: audioBlob } },
+    ],
+    choices: [],
+  })],
+});
+
+const serialised = serializeProject(sourceProject);
+assert.ok(serialised);
+assert.strictEqual(serialised.meta.title, 'Persistent Adventure');
+assert.strictEqual(serialised.scenes[0].image.blob, imageBlob, 'image blob should survive serialisation');
+assert.strictEqual(serialised.scenes[0].image.objectUrl, undefined, 'objectUrl should be stripped from serialised data');
+
+const hydrated = hydrateProject(serialised, { previousProject: sourceProject });
+assert.strictEqual(hydrated.meta.title, 'Persistent Adventure');
+assert.strictEqual(hydrated.scenes[0].image.blob, imageBlob, 'image blob should survive hydration');
+assert.ok(typeof hydrated.scenes[0].image.objectUrl === 'string', 'hydrated image should receive a fresh objectUrl');
+assert.notStrictEqual(hydrated.scenes[0].image.objectUrl, 'blob:legacy-img', 'hydrated objectUrl should differ from legacy value');
+assert.ok(revokedUrls.includes('blob:legacy-img'), 'previous image objectUrl should be revoked');
+assert.ok(revokedUrls.includes('blob:legacy-bg'), 'previous bg audio objectUrl should be revoked');
+assert.ok(revokedUrls.includes('blob:legacy-line'), 'previous dialogue audio objectUrl should be revoked');
+
+revokeProjectObjectUrls(hydrated);
+assert.ok(revokedUrls.includes(hydrated.scenes[0].image.objectUrl), 'revoking hydrated project should revoke new objectUrl');
+
+URL.createObjectURL = originalCreateObjectURL;
+URL.revokeObjectURL = originalRevokeObjectURL;
+
+const store = new Store();
+let persistenceMessage = '';
+const cleanup = await setupPersistence(store, { showMessage: (msg) => { persistenceMessage = msg; } });
+assert.strictEqual(typeof cleanup, 'function', 'setupPersistence should return a cleanup function');
+cleanup();
+assert.ok(persistenceMessage.includes('Autosave disabled'), 'fallback message should mention autosave being disabled');
+
+const exportStore = new Store();
+exportStore.set({ project: hydrated });
+const { archiveData, payload } = await createProjectArchive(exportStore.get().project);
+assert.ok(archiveData instanceof Uint8Array, 'archive should return Uint8Array data');
+assert.strictEqual(payload.manifestVersion, 1, 'manifest version should be recorded');
+
+const archiveEntries = await unzip(archiveData);
+assert.ok(archiveEntries['project.json'], 'archive must contain project.json');
+const mediaPaths = Object.keys(archiveEntries).filter(key => key !== 'project.json');
+assert.strictEqual(mediaPaths.length, 3, 'image + background audio + dialogue audio should be exported');
+const manifestJson = JSON.parse(new TextDecoder().decode(archiveEntries['project.json']));
+assert.strictEqual(manifestJson.project.scenes[0].image.path, mediaPaths.find(path => path.includes('image')), 'manifest must reference image path');
+
+const archiveBlob = new Blob([archiveData], { type: 'application/zip' });
+const archiveFile = new File([archiveBlob], 'persistent-adventure.zip', { type: 'application/zip' });
+const importStore = new Store();
+await importProject(importStore, archiveFile);
+const importedProject = importStore.get().project;
+assert.strictEqual(importedProject.meta.title, 'Persistent Adventure', 'imported project should hydrate meta data');
+assert.ok(importedProject.scenes[0].image.blob instanceof Blob, 'image blob should be recreated');
+assert.ok(importedProject.scenes[0].backgroundAudio.blob instanceof Blob, 'background audio blob should be recreated');
+assert.ok(importedProject.scenes[0].dialogue[0].audio.blob instanceof Blob, 'dialogue audio blob should be recreated');
+assert.ok(typeof importedProject.scenes[0].image.objectUrl === 'string', 'image object URL should be restored');
+assert.strictEqual(await importedProject.scenes[0].image.blob.text(), 'image-data', 'image blob data should round-trip');
+assert.strictEqual(await importedProject.scenes[0].dialogue[0].audio.blob.text(), 'audio-data', 'dialogue audio data should round-trip');
+
+const legacySnapshot = {
+  meta: { title: 'Legacy Project', version: 1 },
+  scenes: [{
+    id: 'scene-legacy',
+    type: SceneType.START,
+    image: { name: 'legacy.png' },
+    backgroundAudio: null,
+    dialogue: [{ text: 'Hi there', audio: { name: 'legacy.mp3' } }],
+    choices: [],
+    autoNextSceneId: null,
+    notes: '',
+  }],
+  assets: [],
+};
+const legacyFile = new File([JSON.stringify(legacySnapshot, null, 2)], 'legacy.json', { type: 'application/json' });
+const legacyStore = new Store();
+await importProject(legacyStore, legacyFile);
+const legacyProject = legacyStore.get().project;
+assert.strictEqual(legacyProject.meta.title, 'Legacy Project', 'legacy import should hydrate meta');
+assert.ok(!legacyProject.scenes[0].image.blob, 'legacy import should leave missing media blobs null');
+assert.ok(!legacyProject.scenes[0].dialogue[0].audio.blob, 'legacy dialogue audio should be null without binary');
+
+console.log('storage persistence helpers tests passed');


### PR DESCRIPTION
## Summary
- add background audio metadata to scenes and expose upload/remove controls in the editor inspector
- persist background audio names through storage import/export and loop playback in the player with cleanup
- add unit coverage ensuring background tracks start after Begin Story, survive re-renders, and stop on scene change

## Testing
- for test in tests/*.mjs; do node "$test"; done

------
https://chatgpt.com/codex/tasks/task_e_68de289600888322b6ccde56a0eb8827