### PR TITLE
Enable editing the project title

### DIFF
--- a/public/scripts/editor/editor.js
+++ b/public/scripts/editor/editor.js
@@ -81,6 +81,7 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
     const validationResults = validateProject(project);
 
     renderInspector(inspectorHost, project, scene, {
+      onUpdateProjectTitle: updateProjectTitle,
       onAddScene: addScene,
       onDeleteScene: deleteScene,
       onSetSceneType: setSceneType,
@@ -115,6 +116,17 @@ export function renderEditor(store, leftEl, rightEl, showMessage) {
         }
       }
     }
+  }
+
+  function updateProjectTitle(title) {
+    const value = typeof title === 'string' ? title : '';
+    mutateProject(prev => ({
+      ...prev,
+      meta: {
+        ...(prev.meta || {}),
+        title: value,
+      },
+    }));
   }
 
   function addScene() {

--- a/public/scripts/editor/inspector.js
+++ b/public/scripts/editor/inspector.js
@@ -4,6 +4,21 @@ export function renderInspector(hostEl, project, scene, actions) {
   hostEl.innerHTML = '';
   hostEl.classList.add('inspector');
 
+  const projectTitleField = document.createElement('label');
+  projectTitleField.className = 'field';
+  projectTitleField.innerHTML = '<span>Project title</span>';
+  const projectTitleInput = document.createElement('input');
+  projectTitleInput.type = 'text';
+  projectTitleInput.value = project.meta?.title ?? '';
+  projectTitleInput.placeholder = 'Untitled Role Play';
+  projectTitleInput.maxLength = 120;
+  projectTitleInput.dataset.focusKey = 'project-title';
+  projectTitleInput.addEventListener('input', () => {
+    actions.onUpdateProjectTitle?.(projectTitleInput.value);
+  });
+  projectTitleField.appendChild(projectTitleInput);
+  hostEl.appendChild(projectTitleField);
+
   if (!scene) {
     const empty = document.createElement('p');
     empty.textContent = 'No scenes yet. Use “Add Scene” to begin.';


### PR DESCRIPTION
## Summary
- add a project title text field to the inspector so authors can rename their story
- persist title edits through the editor store to keep the player and exports in sync

## Testing
- for f in tests/*.test.mjs; do echo "Running $f"; node "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68df29acd6b88322bb0fc61ec0621476