### PR TITLE
Adjust stage layout and image scaling

### DIFF
--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -276,16 +276,20 @@ export function renderPlayerUI({
     return () => dialogueAudio.stop();
   }
 
+  const stageMedia = document.createElement('div');
+  stageMedia.className = 'stage-media';
+  stageEl.appendChild(stageMedia);
+
   if (scene.image?.objectUrl) {
     const img = document.createElement('img');
     img.src = scene.image.objectUrl;
     img.alt = `${scene.id} artwork`;
-    stageEl.appendChild(img);
+    stageMedia.appendChild(img);
   } else {
     const emptyStage = document.createElement('div');
     emptyStage.className = 'stage-empty';
     emptyStage.textContent = 'No stage image';
-    stageEl.appendChild(emptyStage);
+    stageMedia.appendChild(emptyStage);
   }
 
   if (backgroundAudioControls) {

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -125,8 +125,8 @@ button:disabled {
   box-shadow: var(--shadow-soft);
 }
 .stage img {
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   object-position: center;
 }

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -118,8 +118,8 @@ button:disabled {
   aspect-ratio: 16 / 9;
   width: 100%;
   min-height: 300px;
-  background: #111;
-  color: #eee;
+  background: var(--color-surface-alt);
+  color: var(--color-text);
   border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: var(--shadow-soft);
@@ -130,7 +130,7 @@ button:disabled {
   object-fit: contain;
   object-position: center;
 }
-.stage-empty { padding: var(--space-lg); color: #9ca3af; }
+.stage-empty { padding: var(--space-lg); color: var(--color-text-muted); }
 .graph-container { min-height: 100%; overflow: auto; padding: var(--space-md); }
 .graph-empty { color: var(--color-text-muted); text-align: center; margin-top: var(--space-lg); }
 .graph-host { display: flex; justify-content: center; align-items: flex-start; }

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -124,9 +124,16 @@ button:disabled {
   overflow: hidden;
   box-shadow: var(--shadow-soft);
 }
-.stage img {
+.stage-media {
   width: 100%;
   height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.stage-media img {
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
   object-position: center;
 }

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -99,13 +99,37 @@ button:disabled {
 .app-messages__details { display: grid; gap: var(--space-2xs); }
 .app-messages__dismiss { border: none; background: transparent; font-size: 1.25rem; line-height: 1; cursor: pointer; color: inherit; padding: var(--space-2xs); border-radius: var(--radius-xs); transition: background-color 0.2s ease; }
 .app-messages__dismiss:hover { background: rgba(15, 23, 42, 0.08); }
-.layout { flex: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 0; }
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 0;
+  min-height: 0;
+}
 .layout.layout--edit { grid-template-columns: minmax(0, 0.65fr) minmax(0, 0.35fr); }
 .pane { border-right: 1px solid var(--color-border-subtle); padding: var(--space-md); overflow: auto; background: var(--color-surface); }
 .pane:last-child { border-right: none; }
 .placeholder { border: 2px dashed var(--color-border); border-radius: var(--radius-md); padding: var(--space-lg); text-align: center; color: var(--color-text-muted); background: var(--color-surface); box-shadow: var(--shadow-subtle); }
-.stage { display: flex; align-items: center; justify-content: center; min-height: 300px; background: #111; color: #eee; border-radius: var(--radius-md); overflow: hidden; box-shadow: var(--shadow-soft); }
-.stage img { width: 100%; height: 100%; object-fit: cover; }
+.stage {
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: var(--space-md);
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  min-height: 300px;
+  background: #111;
+  color: #eee;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+.stage img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  object-position: center;
+}
 .stage-empty { padding: var(--space-lg); color: #9ca3af; }
 .graph-container { min-height: 100%; overflow: auto; padding: var(--space-md); }
 .graph-empty { color: var(--color-text-muted); text-align: center; margin-top: var(--space-lg); }


### PR DESCRIPTION
## Summary
- switch the player layout to a 60/40 grid split on large screens while preserving the single-column mobile fallback
- give the stage a fixed 16:9 aspect ratio with padded letterboxing for better scaling
- ensure stage images use contain/center sizing so portrait and landscape uploads stay visible

## Testing
- Manual verification in browser (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68df4cdd02b88322869a468856405ed2