### PR TITLE
Refine player dialogue bubbles with inline audio controls

### DIFF
--- a/public/scripts/player/player.js
+++ b/public/scripts/player/player.js
@@ -259,6 +259,20 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
     goToHistoryIndex(historyIndex + delta);
   }
 
+  const HISTORY_LABEL_MAX_LENGTH = 30;
+
+  const truncateHistoryLabel = (text) => {
+    if (!text) {
+      return text;
+    }
+    const glyphs = Array.from(text);
+    if (glyphs.length <= HISTORY_LABEL_MAX_LENGTH) {
+      return text;
+    }
+    const sliceLength = Math.max(1, HISTORY_LABEL_MAX_LENGTH - 1);
+    return `${glyphs.slice(0, sliceLength).join('')}…`;
+  };
+
   function createHistoryControls(project) {
     if (!sceneHistory.length) {
       return null;
@@ -272,8 +286,9 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
         }
         const fallback = scene.id || sceneId;
         const firstLine = scene.dialogue?.[0]?.text?.trim();
-        const label = firstLine ? firstLine : fallback;
-        return { sceneId, label };
+        const fullLabel = firstLine || fallback;
+        const label = truncateHistoryLabel(fullLabel);
+        return { sceneId, label, fullLabel };
       })
       .filter(Boolean);
 

--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -420,7 +420,13 @@ export function renderPlayerUI({
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'player-history-entry';
-      button.textContent = entry.label || entry.sceneId;
+      const displayLabel = entry.label ?? entry.fullLabel ?? entry.sceneId;
+      const accessibleLabel = entry.fullLabel ?? entry.label ?? entry.sceneId;
+      button.textContent = displayLabel || '';
+      if (accessibleLabel) {
+        button.setAttribute('title', accessibleLabel);
+        button.setAttribute('aria-label', accessibleLabel);
+      }
       if (button.dataset) {
         button.dataset.sceneId = entry.sceneId;
       }

--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -491,14 +491,18 @@ export function renderPlayerUI({
     const lineContainer = document.createElement('div');
     lineContainer.className = 'player-dialogue-line';
 
+    const bubble = document.createElement('div');
+    bubble.className = 'player-dialogue-bubble';
+    lineContainer.appendChild(bubble);
+
     const text = document.createElement('p');
     text.textContent = line.text || `(Line ${index + 1})`;
-    lineContainer.appendChild(text);
+    bubble.appendChild(text);
 
     if (line.audio?.objectUrl) {
       const playButton = document.createElement('button');
       playButton.type = 'button';
-      playButton.className = 'audio-play';
+      playButton.className = 'dialogue-bubble-play';
       playButton.textContent = '▶️ Play line';
       playButton.setAttribute('aria-pressed', 'false');
 
@@ -527,7 +531,7 @@ export function renderPlayerUI({
           },
         });
       });
-      lineContainer.appendChild(playButton);
+      bubble.appendChild(playButton);
     }
 
     dialogueBox.appendChild(lineContainer);

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -156,12 +156,44 @@ button:disabled {
 }
 .player-history-nav button:hover:not(:disabled) { background: var(--color-surface-alt); box-shadow: none; }
 .player-history-nav button:disabled { opacity: 0.6; cursor: not-allowed; }
-.player-history-list { list-style: none; display: flex; flex-wrap: wrap; gap: var(--space-xs); margin: 0; padding: 0; }
-.player-history-list li { margin: 0; }
-.player-history-entry { padding: var(--space-2xs) var(--space-sm); border: 1px solid var(--color-border); border-radius: 999px; background: var(--color-surface); color: var(--color-text); cursor: pointer; transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+.player-history-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0;
+  row-gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+}
+.player-history-list li {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+}
+.player-history-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
 .player-history-entry:hover:not(:disabled) { background: var(--color-surface-alt); box-shadow: var(--shadow-subtle); }
 .player-history-entry:disabled { cursor: default; opacity: 0.85; }
 .player-history-entry[aria-current] { background: var(--color-accent); border-color: var(--color-accent); color: #fff; cursor: default; box-shadow: var(--shadow-subtle); }
+.player-history-list li + li::before {
+  content: '→';
+  color: currentColor;
+  font-size: 0.85em;
+  line-height: 1;
+  margin: 0 var(--space-2xs);
+}
 .player-dialogue { display: grid; gap: var(--space-sm); padding: var(--space-md); background: var(--color-surface); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); box-shadow: var(--shadow-subtle); }
 .player-dialogue-line { display: flex; justify-content: flex-start; padding-bottom: var(--space-xs); width: 100%; }
 .player-dialogue-bubble {

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -178,6 +178,17 @@ button:disabled {
   max-width: 100%;
   width: 100%;
 }
+.player-dialogue-bubble::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 2px solid transparent;
+  opacity: 0;
+  transform: scale(0.98);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
 .player-dialogue-bubble::after {
   content: '';
   position: absolute;
@@ -190,6 +201,22 @@ button:disabled {
   border-right: 1px solid var(--color-border-subtle);
   transform: rotate(45deg);
   box-shadow: 2px 2px 4px rgba(15, 23, 42, 0.06);
+}
+.player-dialogue-bubble.is-playing {
+  background: rgba(37, 99, 235, 0.12);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.25), var(--shadow-subtle);
+}
+.player-dialogue-bubble.is-playing::after {
+  background: rgba(37, 99, 235, 0.12);
+  border-bottom-color: var(--color-accent);
+  border-right-color: var(--color-accent);
+  box-shadow: 2px 2px 6px rgba(37, 99, 235, 0.2);
+}
+.player-dialogue-bubble.is-playing::before {
+  border-color: rgba(37, 99, 235, 0.35);
+  opacity: 1;
+  transform: scale(1);
 }
 .player-dialogue-bubble p {
   margin: 0;
@@ -208,6 +235,30 @@ button:disabled {
 }
 .dialogue-bubble-play:hover:not(:disabled) {
   background: var(--color-surface-alt);
+}
+.player-dialogue-bubble.is-playing .dialogue-bubble-play {
+  border-color: var(--color-accent);
+}
+
+@keyframes playerDialogueBubblePulse {
+  0% {
+    opacity: 0.4;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 0.75;
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0.4;
+    transform: scale(0.96);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .player-dialogue-bubble.is-playing::before {
+    animation: playerDialogueBubblePulse 2.4s ease-in-out infinite;
+  }
 }
 .player-choices { display: grid; gap: var(--space-xs); }
 .player-choices button {

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -163,10 +163,10 @@ button:disabled {
 .player-history-entry:disabled { cursor: default; opacity: 0.85; }
 .player-history-entry[aria-current] { background: var(--color-accent); border-color: var(--color-accent); color: #fff; cursor: default; box-shadow: var(--shadow-subtle); }
 .player-dialogue { display: grid; gap: var(--space-sm); padding: var(--space-md); background: var(--color-surface); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); box-shadow: var(--shadow-subtle); }
-.player-dialogue-line { display: flex; justify-content: flex-start; padding-bottom: var(--space-xs); }
+.player-dialogue-line { display: flex; justify-content: flex-start; padding-bottom: var(--space-xs); width: 100%; }
 .player-dialogue-bubble {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: flex-start;
   flex-wrap: wrap;
   gap: var(--space-sm);
@@ -176,6 +176,7 @@ button:disabled {
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-subtle);
   max-width: 100%;
+  width: 100%;
 }
 .player-dialogue-bubble::after {
   content: '';

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -163,8 +163,51 @@ button:disabled {
 .player-history-entry:disabled { cursor: default; opacity: 0.85; }
 .player-history-entry[aria-current] { background: var(--color-accent); border-color: var(--color-accent); color: #fff; cursor: default; box-shadow: var(--shadow-subtle); }
 .player-dialogue { display: grid; gap: var(--space-sm); padding: var(--space-md); background: var(--color-surface); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); box-shadow: var(--shadow-subtle); }
-.player-dialogue-line { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); }
-.audio-play { padding: var(--space-2xs) var(--space-sm); }
+.player-dialogue-line { display: flex; justify-content: flex-start; padding-bottom: var(--space-xs); }
+.player-dialogue-bubble {
+  position: relative;
+  display: inline-flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-subtle);
+  max-width: 100%;
+}
+.player-dialogue-bubble::after {
+  content: '';
+  position: absolute;
+  left: calc(var(--space-md) + 0.25rem);
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-border-subtle);
+  border-right: 1px solid var(--color-border-subtle);
+  transform: rotate(45deg);
+  box-shadow: 2px 2px 4px rgba(15, 23, 42, 0.06);
+}
+.player-dialogue-bubble p {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.dialogue-bubble-play {
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  box-shadow: none;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+}
+.dialogue-bubble-play:hover:not(:disabled) {
+  background: var(--color-surface-alt);
+}
 .player-choices { display: grid; gap: var(--space-xs); }
 .player-choices button {
   padding: var(--space-sm) var(--space-md);

--- a/tests/player-history.test.mjs
+++ b/tests/player-history.test.mjs
@@ -135,6 +135,20 @@ function getHistoryButtons(root) {
   return buttons;
 }
 
+const HISTORY_LABEL_MAX_LENGTH = 30;
+
+function truncateHistoryLabel(text) {
+  if (!text) {
+    return text;
+  }
+  const glyphs = Array.from(text);
+  if (glyphs.length <= HISTORY_LABEL_MAX_LENGTH) {
+    return text;
+  }
+  const sliceLength = Math.max(1, HISTORY_LABEL_MAX_LENGTH - 1);
+  return `${glyphs.slice(0, sliceLength).join('')}…`;
+}
+
 function logResult(label, condition) {
   const status = condition ? 'OK' : 'FAIL';
   console.log(`${status}: ${label}`);
@@ -154,7 +168,11 @@ const project = {
       type: SceneType.START,
       image: null,
       backgroundAudio: null,
-      dialogue: [{ text: 'Opening scene', audio: null }],
+      dialogue: [{
+        text:
+          'This is a very long first line that should be truncated in the history panel to keep things tidy.',
+        audio: null,
+      }],
       choices: [
         { id: 'c1', label: 'To middle', nextSceneId: 'middle' },
         { id: 'c2', label: 'Alternate path', nextSceneId: 'alt' },
@@ -218,6 +236,13 @@ logResult(
   'Initial entry marked current',
   historyButtons.length === 1 && historyButtons[0].disabled && historyButtons[0].getAttribute('aria-current') === 'step',
 );
+
+const initialHistoryButton = historyButtons[0];
+const longFirstLine = project.scenes[0].dialogue[0].text;
+const expectedTruncatedLabel = truncateHistoryLabel(longFirstLine);
+logResult('History entry label truncated', initialHistoryButton?.textContent === expectedTruncatedLabel);
+logResult('History entry title retains full text', initialHistoryButton?.getAttribute('title') === longFirstLine);
+logResult('History entry aria-label retains full text', initialHistoryButton?.getAttribute('aria-label') === longFirstLine);
 
 let backButton = findElement(uiHost, el => (el.className || '') === 'player-history-back');
 logResult('Back button disabled at start', Boolean(backButton?.disabled));


### PR DESCRIPTION
## Summary
- wrap each player dialogue line in a bubble container and keep inline audio controls wired to the existing playback logic
- restyle the dialogue list to present rounded bubbles with inline play buttons that remain accessible for keyboard users

## Testing
- for f in tests/*.test.mjs; do node "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68df8e28e3e8832285b7288ba194e1bf