### PR TITLE
Truncate story history labels and preserve full text

### DIFF
--- a/public/scripts/player/player.js
+++ b/public/scripts/player/player.js
@@ -259,6 +259,20 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
     goToHistoryIndex(historyIndex + delta);
   }
 
+  const HISTORY_LABEL_MAX_LENGTH = 30;
+
+  const truncateHistoryLabel = (text) => {
+    if (!text) {
+      return text;
+    }
+    const glyphs = Array.from(text);
+    if (glyphs.length <= HISTORY_LABEL_MAX_LENGTH) {
+      return text;
+    }
+    const sliceLength = Math.max(1, HISTORY_LABEL_MAX_LENGTH - 1);
+    return `${glyphs.slice(0, sliceLength).join('')}…`;
+  };
+
   function createHistoryControls(project) {
     if (!sceneHistory.length) {
       return null;
@@ -272,8 +286,9 @@ export function renderPlayer(store, leftEl, rightEl, showMessage) {
         }
         const fallback = scene.id || sceneId;
         const firstLine = scene.dialogue?.[0]?.text?.trim();
-        const label = firstLine ? firstLine : fallback;
-        return { sceneId, label };
+        const fullLabel = firstLine || fallback;
+        const label = truncateHistoryLabel(fullLabel);
+        return { sceneId, label, fullLabel };
       })
       .filter(Boolean);
 

--- a/public/scripts/player/ui.js
+++ b/public/scripts/player/ui.js
@@ -420,7 +420,13 @@ export function renderPlayerUI({
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'player-history-entry';
-      button.textContent = entry.label || entry.sceneId;
+      const displayLabel = entry.label ?? entry.fullLabel ?? entry.sceneId;
+      const accessibleLabel = entry.fullLabel ?? entry.label ?? entry.sceneId;
+      button.textContent = displayLabel || '';
+      if (accessibleLabel) {
+        button.setAttribute('title', accessibleLabel);
+        button.setAttribute('aria-label', accessibleLabel);
+      }
       if (button.dataset) {
         button.dataset.sceneId = entry.sceneId;
       }

--- a/tests/player-history.test.mjs
+++ b/tests/player-history.test.mjs
@@ -135,6 +135,20 @@ function getHistoryButtons(root) {
   return buttons;
 }
 
+const HISTORY_LABEL_MAX_LENGTH = 30;
+
+function truncateHistoryLabel(text) {
+  if (!text) {
+    return text;
+  }
+  const glyphs = Array.from(text);
+  if (glyphs.length <= HISTORY_LABEL_MAX_LENGTH) {
+    return text;
+  }
+  const sliceLength = Math.max(1, HISTORY_LABEL_MAX_LENGTH - 1);
+  return `${glyphs.slice(0, sliceLength).join('')}…`;
+}
+
 function logResult(label, condition) {
   const status = condition ? 'OK' : 'FAIL';
   console.log(`${status}: ${label}`);
@@ -154,7 +168,11 @@ const project = {
       type: SceneType.START,
       image: null,
       backgroundAudio: null,
-      dialogue: [{ text: 'Opening scene', audio: null }],
+      dialogue: [{
+        text:
+          'This is a very long first line that should be truncated in the history panel to keep things tidy.',
+        audio: null,
+      }],
       choices: [
         { id: 'c1', label: 'To middle', nextSceneId: 'middle' },
         { id: 'c2', label: 'Alternate path', nextSceneId: 'alt' },
@@ -218,6 +236,13 @@ logResult(
   'Initial entry marked current',
   historyButtons.length === 1 && historyButtons[0].disabled && historyButtons[0].getAttribute('aria-current') === 'step',
 );
+
+const initialHistoryButton = historyButtons[0];
+const longFirstLine = project.scenes[0].dialogue[0].text;
+const expectedTruncatedLabel = truncateHistoryLabel(longFirstLine);
+logResult('History entry label truncated', initialHistoryButton?.textContent === expectedTruncatedLabel);
+logResult('History entry title retains full text', initialHistoryButton?.getAttribute('title') === longFirstLine);
+logResult('History entry aria-label retains full text', initialHistoryButton?.getAttribute('aria-label') === longFirstLine);
 
 let backButton = findElement(uiHost, el => (el.className || '') === 'player-history-back');
 logResult('Back button disabled at start', Boolean(backButton?.disabled));


### PR DESCRIPTION
## Summary
- truncate story history labels while retaining the full text for accessibility metadata
- update player history buttons to surface truncated labels with tooltips and aria labels
- extend the player history regression test to cover long opening lines

## Testing
- for f in tests/*.test.mjs; do echo "Running $f"; node "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68dfc84ce3cc83229752755fbf664d6d